### PR TITLE
Add reusable Octopus Deploy package and release action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,53 @@
 # GitHub Actions
 
+## Octopus Deploy Package and Release
+
+This action creates an Octopus Deploy package, uploads it, and creates a release in a single step.
+
+### Usage
+
+```yaml
+- name: Deploy to Octopus
+  uses: maestra-io/github-actions/octopus-package-release@main
+  with:
+    octopusProject: my-project
+    version: ${{ steps.release-number.outputs.release-number }}
+    folderToPack: helmfile/**
+    space: Default
+    releaseNotes: ${{ steps.create-release.outputs.release-notes-body }}
+    OCTOPUS_CLI_API_KEY: ${{ env.OCTOPUS_API_KEY }}
+    OCTOPUS_CLI_SERVER: ${{ env.OCTOPUS_CLI_SERVER }}
+```
+
+### Inputs
+
+- `octopusProject`: Octopus project name (required)
+- `version`: Package and release version (required)
+- `folderToPack`: Folder to include in package, e.g., `helmfile/**`, `terraform/**` (required)
+- `space`: Octopus space name (optional, defaults to "Default")
+- `releaseNotes`: Release notes for the Octopus release (optional)
+- `OCTOPUS_CLI_API_KEY`: Octopus API key (required)
+- `OCTOPUS_CLI_SERVER`: Octopus server URL (required)
+
+### Outputs
+
+- `package-path`: Path to the created package file
+
+### Example
+
+```yaml
+- name: Deploy with release notes
+  uses: maestra-io/github-actions/octopus-package-release@main
+  with:
+    octopusProject: shopify-webhooks
+    version: 1.2.3
+    folderToPack: helmfile/**
+    space: Production
+    releaseNotes: "Bug fixes and performance improvements"
+    OCTOPUS_CLI_API_KEY: ${{ secrets.OCTOPUS_API_KEY }}
+    OCTOPUS_CLI_SERVER: https://octopus.mindbox.ru
+```
+
 ## Push to AWS ECR repositories
 
 This action pushes multiple Docker images to AWS ECR repositories.

--- a/octopus-package-release/action.yml
+++ b/octopus-package-release/action.yml
@@ -72,6 +72,7 @@ runs:
           --project ${{ inputs.octopusProject }}
           --version ${{ inputs.version }}
           --packageVersion ${{ inputs.version }}
+          --space ${{ inputs.space }}
           ${{ inputs.releaseNotes != '' && format('--releasenotes "{0}"', inputs.releaseNotes) || '' }}
       env:
         OCTOPUS_CLI_API_KEY: ${{ inputs.OCTOPUS_CLI_API_KEY }}

--- a/octopus-package-release/action.yml
+++ b/octopus-package-release/action.yml
@@ -1,0 +1,78 @@
+name: 'Octopus Deploy Package and Release'
+description: 'Create and upload Octopus package, then create a release'
+inputs:
+  octopusProject:
+    description: 'Octopus project name'
+    required: true
+  version:
+    description: 'Package and release version'
+    required: true
+  folderToPack:
+    description: 'Folder to include in the package (e.g., helmfile/**, terraform/**)'
+    required: true
+  space:
+    description: 'Octopus space name'
+    required: false
+    default: 'Default'
+  releaseNotes:
+    description: 'Release notes for the Octopus release'
+    required: false
+    default: ''
+  OCTOPUS_CLI_API_KEY:
+    description: 'Octopus API key'
+    required: true
+  OCTOPUS_CLI_SERVER:
+    description: 'Octopus server URL'
+    required: true
+outputs:
+  package-path:
+    description: 'Path to the created package'
+    value: ${{ steps.package-info.outputs.package-path }}
+runs:
+  using: "composite"
+  steps:
+    - name: Set package info
+      id: package-info
+      shell: bash
+      run: |
+        echo "package-path=./packages/${{ inputs.octopusProject }}.${{ inputs.version }}.zip" >> $GITHUB_OUTPUT
+
+    - name: Create and upload octopus package
+      uses: docker://octopusdeploy/octo
+      with:
+        args: >-
+          pack
+          --id ${{ inputs.octopusProject }}
+          --version ${{ inputs.version }}
+          --outFolder ./packages
+          --include ${{ inputs.folderToPack }}
+          --format Zip
+          --verbose
+          --overwrite
+      env:
+        OCTOPUS_CLI_API_KEY: ${{ inputs.OCTOPUS_CLI_API_KEY }}
+        OCTOPUS_CLI_SERVER: ${{ inputs.OCTOPUS_CLI_SERVER }}
+
+    - name: Upload octopus package
+      uses: docker://octopusdeploy/octo
+      with:
+        args: >-
+          push
+          --package ${{ steps.package-info.outputs.package-path }}
+          --space ${{ inputs.space }}
+      env:
+        OCTOPUS_CLI_API_KEY: ${{ inputs.OCTOPUS_CLI_API_KEY }}
+        OCTOPUS_CLI_SERVER: ${{ inputs.OCTOPUS_CLI_SERVER }}
+
+    - name: Create octopus release
+      uses: docker://octopusdeploy/octo
+      with:
+        args: >-
+          create-release
+          --project ${{ inputs.octopusProject }}
+          --version ${{ inputs.version }}
+          --packageVersion ${{ inputs.version }}
+          ${{ inputs.releaseNotes != '' && format('--releasenotes "{0}"', inputs.releaseNotes) || '' }}
+      env:
+        OCTOPUS_CLI_API_KEY: ${{ inputs.OCTOPUS_CLI_API_KEY }}
+        OCTOPUS_CLI_SERVER: ${{ inputs.OCTOPUS_CLI_SERVER }}


### PR DESCRIPTION
## Summary
- Created reusable GitHub action for Octopus Deploy package and release operations
- Consolidates package creation, upload, and release steps into single action
- Provides configurable inputs for project, version, folder to pack, space, and release notes

## Features
- **Configurable inputs**: octopusProject, version, folderToPack, space, releaseNotes
- **Environment variables**: OCTOPUS_CLI_API_KEY, OCTOPUS_CLI_SERVER
- **Output**: package-path for downstream use
- **Docker-based**: Uses official octopusdeploy/octo image

## Test plan
- [ ] Test action with different folder patterns (helmfile/**, terraform/**)
- [ ] Verify package creation and upload functionality
- [ ] Test release creation with and without release notes
- [ ] Validate with different Octopus spaces

🤖 Generated with [Claude Code](https://claude.ai/code)