### PR TITLE
feat(bake-oci-manifests): add teleport-token + kustomization-path inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,13 +146,30 @@ jobs:
 
 ### Inputs
 
-- `service`: kebab-case service name. Derives `TELEPORT_TOKEN` (`image-push-github-actions-<service>`) and `IMAGE_MANIFESTS` (`<service>-manifests`). **(required)**
+- `service`: kebab-case service name. Used to derive the manifests ECR repo name (`<service>-manifests`) and the default `teleport-token` (`image-push-github-actions-<service>`). **(required)**
 - `images`: comma-separated list of image basenames the action will verify exist in ECR before baking. If any is missing, the bake fails. **(required)**
+- `teleport-token`: Teleport bot join-token name. Default `image-push-github-actions-<service>`. Override for monorepos where one bot serves multiple services (e.g. `image-push-github-actions-mindbox-mta` for `campaigns`/`mta`).
+- `kustomization-path`: Path to the kustomization tree to bake. Default `./kustomization`. Override for monorepos that keep each service's manifests under its own subdir (e.g. `kustomization/campaigns`).
 - `flux-version`: flux CLI version, no `v-` prefix. Default `2.8.6`.
 - `aws-region`: ECR region. Default `eu-central-1`.
 - `ecr-registry`: ECR registry host. Default `515260921971.dkr.ecr.eu-central-1.amazonaws.com`.
 - `teleport-fqdn`: Teleport proxy. Default `teleport.maestra.io:443`.
 - `aws-role-arn`: IAM role assumed via Teleport workload-identity. Default `arn:aws:iam::515260921971:role/teleport-image-push`.
+
+### Monorepo example (campaigns inside maestra-io/Mindbox.MTA)
+
+```yaml
+jobs:
+  bake:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: maestra-io/github-actions/bake-oci-manifests@main
+        with:
+          service: campaigns
+          images: campaigns_services,campaigns_lrt,campaigns_sqlmigrator
+          teleport-token: image-push-github-actions-mindbox-mta
+          kustomization-path: kustomization/campaigns
+```
 
 ### Outputs
 

--- a/bake-oci-manifests/action.yml
+++ b/bake-oci-manifests/action.yml
@@ -7,7 +7,9 @@ description: >-
 
 inputs:
   service:
-    description: 'Service name (kebab-case, e.g. db-migrator). Derives TELEPORT_TOKEN and IMAGE_MANIFESTS.'
+    description: >-
+      Service name (kebab-case, e.g. db-migrator). Used to derive defaults for
+      `teleport-token` and the OCI manifests repo name (`<service>-manifests`).
     required: true
   images:
     description: >-
@@ -15,6 +17,22 @@ inputs:
       baking (e.g. "db_migrator_services,db_migrator_migrator"). The bake refuses
       to proceed if any image is missing for the target tag.
     required: true
+  teleport-token:
+    description: >-
+      Teleport bot join-token name. Defaults to
+      `image-push-github-actions-<service>`. Override when the bot is named
+      per repo rather than per service (e.g. monorepos sharing one bot across
+      multiple services).
+    required: false
+    default: ''
+  kustomization-path:
+    description: >-
+      Path to the kustomization tree that `flux push artifact` packs. Default
+      is `./kustomization` (single-service repo). Override for monorepos that
+      keep each service's manifests under its own subdir
+      (e.g. `kustomization/campaigns`).
+    required: false
+    default: './kustomization'
   flux-version:
     description: 'flux CLI version (without v- prefix).'
     required: false
@@ -84,13 +102,15 @@ runs:
 
     - name: mint Teleport workload-identity JWT for AWS
       shell: bash
+      env:
+        TELEPORT_TOKEN: ${{ inputs.teleport-token != '' && inputs.teleport-token || format('image-push-github-actions-{0}', inputs.service) }}
       run: |
         cat > /tmp/tbot.yaml <<EOF
         version: v2
         proxy_server: ${{ inputs.teleport-fqdn }}
         onboarding:
           join_method: github
-          token: image-push-github-actions-${{ inputs.service }}
+          token: ${TELEPORT_TOKEN}
         oneshot: true
         storage:
           type: memory
@@ -167,22 +187,23 @@ runs:
         flux --version
 
     # ── Substitute the version placeholder ────────────────────────────────
-    # The placeholder lives in kustomization/base/helm-release-{app,init}.yaml
+    # The placeholder lives in <kustomization-path>/base/helm-release-{app,init}.yaml
     # as `packageVersion: ${APP_PACKAGE_VERSION_TO_BE_REPLACED}`. After the
     # sed pass, the bake refuses to push if any placeholder survived.
     - name: substitute APP_PACKAGE_VERSION_TO_BE_REPLACED
       shell: bash
       env:
         TAG: ${{ steps.ver.outputs.version }}
+        KUSTOMIZATION_PATH: ${{ inputs.kustomization-path }}
       run: |
-        find kustomization -type f -name '*.yaml' \
+        find "$KUSTOMIZATION_PATH" -type f -name '*.yaml' \
           -exec sed -i "s|\${APP_PACKAGE_VERSION_TO_BE_REPLACED}|${TAG}|g" {} +
-        if grep -rn '\${APP_PACKAGE_VERSION_TO_BE_REPLACED}' kustomization/ ; then
+        if grep -rn '\${APP_PACKAGE_VERSION_TO_BE_REPLACED}' "$KUSTOMIZATION_PATH" ; then
           echo "::error::APP_PACKAGE_VERSION_TO_BE_REPLACED placeholder still present after substitution"
           exit 1
         fi
         echo "--- packageVersion after substitution ---"
-        grep -rn packageVersion kustomization/base/ || true
+        grep -rn packageVersion "$KUSTOMIZATION_PATH/base/" || true
 
     # ── Bake the OCI artifact ─────────────────────────────────────────────
     - name: flux push artifact
@@ -192,10 +213,11 @@ runs:
         ECR_REGISTRY: ${{ inputs.ecr-registry }}
         IMAGE_MANIFESTS: ${{ inputs.service }}-manifests
         TAG: ${{ steps.ver.outputs.version }}
+        KUSTOMIZATION_PATH: ${{ inputs.kustomization-path }}
       run: |
         out=$(flux push artifact \
           "oci://${ECR_REGISTRY}/${IMAGE_MANIFESTS}:${TAG}" \
-          --path ./kustomization \
+          --path "$KUSTOMIZATION_PATH" \
           --source "https://github.com/${GITHUB_REPOSITORY}" \
           --revision "${GITHUB_SHA}" \
           --output json)


### PR DESCRIPTION
## Summary

Two new optional inputs on the \`bake-oci-manifests\` composite action so monorepos can use it too:

- \`teleport-token\` — override the derived \`image-push-github-actions-<service>\` default. Needed for \`campaigns\` (inside \`maestra-io/Mindbox.MTA\`) where the Teleport bot is \`image-push-github-actions-mindbox-mta\`.
- \`kustomization-path\` — override the \`./kustomization\` default. Needed for the same monorepo case where each service's manifests live under \`kustomization/<service>/\`.

Both are backward-compatible: the 1 production caller (db-migrator) keeps working unchanged.

## Test plan

- [x] Defaults unchanged for single-service repos.
- [ ] After merge: campaigns migration (in maestra-io/Mindbox.MTA) uses both new inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

Added two optional inputs to the `bake-oci-manifests` composite action to support monorepo setups:

- **`teleport-token`**: Allows overriding the derived default Teleport join token (defaults to `image-push-github-actions-<service>` if not provided). Useful in monorepos where the Teleport bot name differs from the service name (e.g., for `campaigns` service in a monorepo, the bot may be named `image-push-github-actions-mindbox-mta`).

- **`kustomization-path`**: Allows overriding the default Kustomization manifest root path (defaults to `./kustomization`). Useful in monorepos that store each service's manifests under subdirectories like `kustomization/<service>/`.

**Updated components:**
- `bake-oci-manifests/action.yml`: Added input definitions and integrated them into the Teleport JWT minting and placeholder substitution steps.
- `README.md`: Updated documentation with examples and clarifications for the new inputs.

**Additional new action files added:**
- `octopus-package-release/action.yml`: New composite action for packaging releases.
- `push-to-aws-ecr-repository/action.yml`: New composite action for ECR operations.
- `push-to-aws-ecr-repository/ecr-policy.json`: IAM policy configuration for ECR access.

**Backward compatibility:** Both new inputs to `bake-oci-manifests` are optional with sensible defaults. Existing single-service repos and current production callers continue to work unchanged.

**No breaking changes.**

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maestra-io/github-actions/pull/6?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->