### PR TITLE
feat(bake-oci-manifests): bake-path input + optional images (support non-kustomization artifacts)

### DIFF
--- a/bake-oci-manifests/action.yml
+++ b/bake-oci-manifests/action.yml
@@ -13,8 +13,20 @@ inputs:
     description: >-
       Comma-separated list of image basenames to verify exist in ECR before
       baking (e.g. "db_migrator_services,db_migrator_migrator"). The bake refuses
-      to proceed if any image is missing for the target tag.
-    required: true
+      to proceed if any image is missing for the target tag. Leave EMPTY for
+      artifacts that ship no app images (e.g. a Terraform-module bundle
+      consumed by a tofu Terraform CR) — the image-verify step is skipped.
+    required: false
+    default: ''
+  bake-path:
+    description: >-
+      Path within the repo packed into the OCI artifact and used for the
+      placeholder substitution + pull-verify. Default './kustomization' (k8s
+      manifest tree). Set './terraform' for a Terraform-module bundle. The
+      ${APP_PACKAGE_VERSION_TO_BE_REPLACED} substitution is a no-op when the
+      tree has no such placeholder (e.g. terraform), so it is safe for both.
+    required: false
+    default: './kustomization'
   flux-version:
     description: 'flux CLI version (without v- prefix).'
     required: false
@@ -119,8 +131,10 @@ runs:
 
     # ── Verify GitLab CI already pushed every image for this tag ──────────
     # If any is missing, refuse to bake the bundle — a manifests artifact
-    # without working images is worse than no artifact at all.
+    # without working images is worse than no artifact at all. Skipped when
+    # `images` is empty (artifact ships no app images, e.g. a TF-module bundle).
     - name: verify images exist
+      if: ${{ inputs.images != '' }}
       shell: bash
       env:
         ECR_REGISTRY: ${{ inputs.ecr-registry }}
@@ -167,22 +181,27 @@ runs:
         flux --version
 
     # ── Substitute the version placeholder ────────────────────────────────
-    # The placeholder lives in kustomization/base/helm-release-{app,init}.yaml
-    # as `packageVersion: ${APP_PACKAGE_VERSION_TO_BE_REPLACED}`. After the
-    # sed pass, the bake refuses to push if any placeholder survived.
+    # For a k8s-manifest tree the placeholder lives in
+    # <bake-path>/base/helm-release-{app,init}.yaml as
+    # `packageVersion: ${APP_PACKAGE_VERSION_TO_BE_REPLACED}`. After the sed
+    # pass, the bake refuses to push if any placeholder survived. For a tree
+    # with no such placeholder (e.g. a terraform bundle) the sed matches
+    # nothing and the guard grep finds nothing — a safe no-op.
     - name: substitute APP_PACKAGE_VERSION_TO_BE_REPLACED
       shell: bash
       env:
         TAG: ${{ steps.ver.outputs.version }}
+        BAKE_PATH: ${{ inputs.bake-path }}
       run: |
-        find kustomization -type f -name '*.yaml' \
+        test -d "$BAKE_PATH" || { echo "::error::bake-path '$BAKE_PATH' not found in repo"; exit 1; }
+        find "$BAKE_PATH" -type f -name '*.yaml' \
           -exec sed -i "s|\${APP_PACKAGE_VERSION_TO_BE_REPLACED}|${TAG}|g" {} +
-        if grep -rn '\${APP_PACKAGE_VERSION_TO_BE_REPLACED}' kustomization/ ; then
+        if grep -rn '\${APP_PACKAGE_VERSION_TO_BE_REPLACED}' "$BAKE_PATH" ; then
           echo "::error::APP_PACKAGE_VERSION_TO_BE_REPLACED placeholder still present after substitution"
           exit 1
         fi
-        echo "--- packageVersion after substitution ---"
-        grep -rn packageVersion kustomization/base/ || true
+        echo "--- packageVersion after substitution (if any) ---"
+        grep -rn packageVersion "$BAKE_PATH" || true
 
     # ── Bake the OCI artifact ─────────────────────────────────────────────
     - name: flux push artifact
@@ -192,10 +211,11 @@ runs:
         ECR_REGISTRY: ${{ inputs.ecr-registry }}
         IMAGE_MANIFESTS: ${{ inputs.service }}-manifests
         TAG: ${{ steps.ver.outputs.version }}
+        BAKE_PATH: ${{ inputs.bake-path }}
       run: |
         out=$(flux push artifact \
           "oci://${ECR_REGISTRY}/${IMAGE_MANIFESTS}:${TAG}" \
-          --path ./kustomization \
+          --path "${BAKE_PATH}" \
           --source "https://github.com/${GITHUB_REPOSITORY}" \
           --revision "${GITHUB_SHA}" \
           --output json)


### PR DESCRIPTION
Backward-compatible extension of the shared OCI bake action so it supports artifacts that are **not** a k8s-manifest kustomization tree — e.g. a Terraform-module bundle consumed by a tofu `Terraform` CR — instead of consumers hand-rolling a divergent inline bake.

### Why
The `auth-jwt-terraform` OCI+Kargo migration needs to bake `./terraform` (no app images, no `packageVersion` placeholder). The action hard-required `images` + ECR image-verify and hardcoded `--path ./kustomization`. The fluxcd-migration skill already *documents* a `kustomization-path` knob — but the action never implemented it. Correct fix = extend the shared action (this PR), not a 150-line inline copy.

### Changes (all backward-compatible)
- **`bake-path`** input, default `./kustomization` — used in the placeholder-substitution `find`/guard-grep, `flux push artifact --path`, and the post-substitution grep. Set `./terraform` for a TF bundle.
- **`images`** now `required: false` (default ``). The *verify images exist* step gets `if: ${{ inputs.images !=  }}` — skipped when empty.
- Added `test -d "$BAKE_PATH"` guard (fail fast on a wrong path).

### Backward-compat
Every existing caller passes `images` explicitly and uses the default kustomization tree → `bake-path` defaults to `./kustomization`, the verify-images step still runs, behaviour is byte-identical. Only new runtime line is the `test -d` which `./kustomization` satisfies.

Follow-ups: `auth-jwt-terraform` `release.yml` becomes the canonical ~35-line caller (`images: ""`, `bake-path: ./terraform`); fluxcd-migration skill doc updated to `bake-path`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes Summary

This PR extends the `bake-oci-manifests` GitHub Action to support bundling artifacts beyond Kubernetes manifest trees (e.g., Terraform modules), making it more flexible for diverse infrastructure-as-code patterns.

### Key Changes

1. **New `bake-path` input** (required: false, default: `./kustomization`)
   - Controls which repo subdirectory is packed into the OCI artifact and used for placeholder substitution
   - Replaces the previously hardcoded `./kustomization` path
   - Supports different artifact types (e.g., `./terraform` for Terraform bundles)
   - Added directory existence check with fail-fast behavior

2. **Made `images` input optional** (required: false, default: `''`)
   - Previously required, now supports artifacts that ship no app images
   - Image verification step is now gated: `if: ${{ inputs.images != '' }}`
   - Allows bundling artifacts like Terraform modules that don't require image verification

3. **Updated placeholder substitution logic**
   - Validates `bake-path` exists before processing
   - Performs `${APP_PACKAGE_VERSION_TO_BE_REPLACED}` substitution only within the specified directory
   - Maintains safety: no-op for trees without the placeholder (e.g., Terraform)
   - Still fails if placeholder persists after substitution

### Backward Compatibility

**No breaking changes.** Existing callers are unaffected:
- `bake-path` defaults to `./kustomization` (preserving original behavior)
- `images` verification continues for callers that explicitly pass image lists
- Added directory guard only impacts custom `bake-path` values (which didn't exist before)
- All other behavior is byte-identical

### Use Cases Enabled

- Terraform-module bundles that ship no app images
- Any artifact type with custom directory paths
- Cleaner migration path for infrastructure tooling alongside container-based services

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maestra-io/github-actions/pull/7?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->