### PR TITLE
feat(bake-oci-manifests): optional `tag` input for native-repo release jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,41 @@ jobs:
           images: db_migrator_services,db_migrator_migrator
 ```
 
+The example above suits a **mirrored** repo, where the bare-semver tag is pushed
+externally (by the GitLab→GitHub mirror) and triggers this workflow.
+
+For a **GitHub-native** repo (no GitLab mirror), the release tag is created in
+the release workflow with `GITHUB_TOKEN`, which cannot trigger a separate
+`on: push: tags` workflow. Bake from a `needs: build` job in the same run and
+pass the tag explicitly via `tag:`:
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      release-number: ${{ steps.release-number.outputs.release-number }}
+    steps:
+      # ... build + push images to ECR, then create the release/tag ...
+  bake:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: maestra-io/github-actions/bake-oci-manifests@main
+        with:
+          service: shopify-webhooks
+          images: shopify_webhooks_services,shopify_webhooks_worker
+          tag: ${{ needs.build.outputs.release-number }}
+```
+
 ### Inputs
 
 - `service`: kebab-case service name. Derives `TELEPORT_TOKEN` (`image-push-github-actions-<service>`) and `IMAGE_MANIFESTS` (`<service>-manifests`). **(required)**
 - `images`: comma-separated list of image basenames the action will verify exist in ECR before baking. If any is missing, the bake fails. **(required)**
+- `tag`: explicit bare-semver tag to bake. Default `''`. When empty, the tag is taken from the `workflow_dispatch` input (if any) or `GITHUB_REF_NAME` (the tag that triggered the run) — the behaviour for mirrored repos. **Set this for GitHub-native repos** that bake from a `needs: build` job in a push-to-`main` release run: there the release tag is created with `GITHUB_TOKEN`, which GitHub will not let trigger a separate `on: push: tags` workflow, and `GITHUB_REF_NAME` is `main` rather than the semver tag. Precedence: `tag` → `workflow_dispatch.inputs.tag` → `GITHUB_REF_NAME`.
 - `flux-version`: flux CLI version, no `v-` prefix. Default `2.8.6`.
 - `aws-region`: ECR region. Default `eu-central-1`.
 - `ecr-registry`: ECR registry host. Default `515260921971.dkr.ecr.eu-central-1.amazonaws.com`.

--- a/bake-oci-manifests/action.yml
+++ b/bake-oci-manifests/action.yml
@@ -9,6 +9,17 @@ inputs:
   service:
     description: 'Service name (kebab-case, e.g. db-migrator). Derives TELEPORT_TOKEN and IMAGE_MANIFESTS.'
     required: true
+  tag:
+    description: >-
+      Explicit bare-semver tag to bake. Use when calling this action from a job
+      that is NOT triggered by a tag push — e.g. a `bake` job in a push-to-main
+      release workflow on a GitHub-native repo, where the release tag is created
+      with GITHUB_TOKEN and so cannot trigger a separate `on: push: tags`
+      workflow. When set, it takes precedence over the workflow_dispatch input
+      and GITHUB_REF_NAME. Leave empty (default) to preserve the
+      tag-push/workflow_dispatch behavior.
+    required: false
+    default: ''
   images:
     description: >-
       Comma-separated list of image basenames to verify exist in ECR before
@@ -63,7 +74,9 @@ runs:
       id: ver
       shell: bash
       run: |
-        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+        if [ -n "${{ inputs.tag }}" ]; then
+          tag="${{ inputs.tag }}"
+        elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
           tag="${{ github.event.inputs.tag }}"
         else
           tag="${GITHUB_REF_NAME}"


### PR DESCRIPTION
## Why
GitHub-native service repos (source on GitHub, **not** a GitLab→GitHub mirror) create their release tag with `GITHUB_TOKEN`. GitHub deliberately does **not** trigger workflows from `GITHUB_TOKEN`-created events (anti-recursion), so a separate `on: push: tags` bake workflow **never fires** for them. (Mirrored repos are fine — the GitLab→GitHub mirror pushes the tag as an external event.)

The fix for native repos is to bake from a `needs: build` job in the **same** push-to-main release run. But there `GITHUB_REF_NAME` is `main`, not the semver tag, so the action's `resolve version` step rejects it.

## What
Add an optional `tag` input (default `''`). Precedence in `resolve version`:
`inputs.tag` → `workflow_dispatch.inputs.tag` → `GITHUB_REF_NAME`.

Fully backward-compatible: when `tag` is empty (every current caller), the existing tag-push / workflow_dispatch behavior is unchanged.

## Caller (native repo)
```yaml
bake:
  needs: build
  permissions: { contents: read, id-token: write }
  steps:
    - uses: maestra-io/github-actions/bake-oci-manifests@main
      with:
        service: shopify-webhooks
        images: shopify_webhooks_services,shopify_webhooks_worker
        tag: ${{ needs.build.outputs.release-number }}
```

First consumer: the Shopify namespaces us-omega migration ([issues-maestra#1073](https://github.com/maestra-io/issues-maestra/issues/1073)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Added an optional `tag` input to the `bake-oci-manifests` GitHub Action to support GitHub-native release workflows (non-mirrored repos) where `GITHUB_REF_NAME` is `main` and workflows triggered by `GITHUB_TOKEN` tag creation won’t fire on `push: tags`.

## Changes

- **Action input added**: `bake-oci-manifests/action.yml`
  - `inputs.tag` (empty default): explicit bare-semver tag to bake.
- **Version resolution updated** in the `resolve version` composite step:
  1. `inputs.tag` (if non-empty)
  2. `workflow_dispatch.inputs.tag` (when applicable)
  3. `GITHUB_REF_NAME` (fallback; preserves prior behavior)
- **Documentation updated** in `README.md` with a GitHub-native (push-to-main) example showing passing `tag: ${{ needs.build.outputs.release-number }}` from a `needs: build` job.

## Backward Compatibility / Breaking Changes

✅ **Fully backward-compatible**: when `tag` is left empty (default), the existing tag-push / workflow_dispatch behavior remains unchanged.

## Lines Changed

+14 / -1
<!-- end of auto-generated comment: release notes by coderabbit.ai -->