### PR TITLE
Add reusable Ansible workflows (run/pr/manual/deploy)

### DIFF
--- a/.github/workflows/ansible-deploy.yml
+++ b/.github/workflows/ansible-deploy.yml
@@ -1,0 +1,160 @@
+# maestra-io/github-actions/.github/workflows/ansible-deploy.yml
+#
+# Reusable APPLY leg for the on-merge deploy pipelines. It is ONE apply job for ONE env
+# with the omega-only approval gate. Repo deploy.yml keeps its own bespoke orchestration
+# (detect-changes, terraform-run interleave, teleport-register-run, strict needs/if chain)
+# and calls this reusable once per ansible env leg. The cross-tool ordering therefore stays
+# in the repo where it belongs; only the ansible apply body is deduplicated.
+name: Ansible Deploy Leg (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      playbook:
+        required: true
+        type: string
+      inventory:
+        description: "Inventory path relative to working_directory"
+        required: false
+        type: string
+        default: "inventory/teleport_inventory.py"
+      working_directory:
+        required: false
+        type: string
+        default: "ansible"
+      region:
+        required: true
+        type: string
+      environment:
+        required: true
+        type: string
+      site:
+        required: true
+        type: string
+      inventory_group_suffix:
+        required: false
+        type: string
+        default: ""
+      tags:
+        required: false
+        type: string
+        default: ""
+      use_mitogen:
+        required: false
+        type: boolean
+        default: true
+      windows_mode:
+        required: false
+        type: boolean
+        default: false
+      vault_mode:
+        required: false
+        type: string
+        default: "none"
+      vault_addr:
+        required: false
+        type: string
+        default: "https://vault.maestra.io"
+      teleport_app:
+        required: false
+        type: string
+        default: ""
+      vault_role:
+        required: false
+        type: string
+        default: ""
+      vault_secrets:
+        required: false
+        type: string
+        default: ""
+      mint_proxmox_token:
+        required: false
+        type: boolean
+        default: false
+      extra_env:
+        required: false
+        type: string
+        default: ""
+      extra_run_args:
+        required: false
+        type: string
+        default: ""
+      host_limit:
+        required: false
+        type: string
+        default: ""
+      no_hosts_fail_on_apply:
+        required: false
+        type: boolean
+        default: true
+      # Force an explicit gate name for repos whose deploy legs name it directly
+      # (e.g. us-omega-lw / eu-omega-lw). Empty -> derive omega-only from environment.
+      gh_environment:
+        required: false
+        type: string
+        default: ""
+      teleport_join_token:
+        required: false
+        type: string
+        default: "github-actions-infra-deploy"
+      teleport_fqdn:
+        required: false
+        type: string
+        default: "teleport.maestra.io:443"
+      requirements_pip:
+        required: false
+        type: string
+        default: "ansible/requirements-pip.txt"
+      requirements_galaxy:
+        required: false
+        type: string
+        default: "ansible/requirements.yml"
+      python_version:
+        required: false
+        type: string
+        default: "3.14"
+    secrets:
+      VECTOR_SIEM_BASIC_AUTH_USER:
+        required: false
+      VECTOR_SIEM_BASIC_AUTH_PASSWORD:
+        required: false
+      PROXMOX_MONITORING_PASSWORD:
+        required: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  apply:
+    uses: ./.github/workflows/ansible-run.yml
+    secrets: inherit
+    with:
+      playbook: ${{ inputs.playbook }}
+      inventory: ${{ inputs.inventory }}
+      working_directory: ${{ inputs.working_directory }}
+      region: ${{ inputs.region }}
+      environment: ${{ inputs.environment }}
+      site: ${{ inputs.site }}
+      inventory_group_suffix: ${{ inputs.inventory_group_suffix }}
+      tags: ${{ inputs.tags }}
+      check_mode: false
+      use_mitogen: ${{ inputs.use_mitogen }}
+      windows_mode: ${{ inputs.windows_mode }}
+      vault_mode: ${{ inputs.vault_mode }}
+      vault_addr: ${{ inputs.vault_addr }}
+      teleport_app: ${{ inputs.teleport_app }}
+      vault_role: ${{ inputs.vault_role }}
+      vault_secrets: ${{ inputs.vault_secrets }}
+      mint_proxmox_token: ${{ inputs.mint_proxmox_token }}
+      extra_env: ${{ inputs.extra_env }}
+      extra_run_args: ${{ inputs.extra_run_args }}
+      host_limit: ${{ inputs.host_limit }}
+      no_hosts_fail_on_apply: ${{ inputs.no_hosts_fail_on_apply }}
+      teleport_join_token: ${{ inputs.teleport_join_token }}
+      teleport_fqdn: ${{ inputs.teleport_fqdn }}
+      requirements_pip: ${{ inputs.requirements_pip }}
+      requirements_galaxy: ${{ inputs.requirements_galaxy }}
+      python_version: ${{ inputs.python_version }}
+      artifact_name: ansible-apply-${{ inputs.region }}-${{ inputs.environment }}-${{ inputs.site }}${{ inputs.inventory_group_suffix }}
+      gh_environment: ${{ inputs.gh_environment != '' && inputs.gh_environment || (inputs.environment == 'omega' && format('{0}-{1}-{2}', inputs.region, inputs.environment, inputs.site) || '') }}

--- a/.github/workflows/ansible-manual.yml
+++ b/.github/workflows/ansible-manual.yml
@@ -1,0 +1,164 @@
+# maestra-io/github-actions/.github/workflows/ansible-manual.yml
+#
+# Reusable manual-dispatch variant. A per-repo caller wires its workflow_dispatch inputs
+# (region/environment/site/check_mode/verbosity/host_limit/tags[/playbook]) straight through,
+# computes the omega-only gh_environment, and delegates to ansible-run.yml.
+#
+# This is a thin reusable so that all callers share the identical gh_environment gating rule
+# (only environment==omega gets a GitHub Environment approval gate).
+name: Ansible Manual (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      playbook:
+        required: true
+        type: string
+      inventory:
+        description: "Inventory path relative to working_directory"
+        required: false
+        type: string
+        default: "inventory/teleport_inventory.py"
+      working_directory:
+        required: false
+        type: string
+        default: "ansible"
+      region:
+        required: true
+        type: string
+      environment:
+        required: true
+        type: string
+      site:
+        required: true
+        type: string
+      inventory_group_suffix:
+        required: false
+        type: string
+        default: ""
+      check_mode:
+        required: false
+        type: boolean
+        default: false
+      verbosity:
+        required: false
+        type: string
+        default: "normal"
+      host_limit:
+        required: false
+        type: string
+        default: ""
+      tags:
+        required: false
+        type: string
+        default: ""
+      use_mitogen:
+        required: false
+        type: boolean
+        default: true
+      windows_mode:
+        required: false
+        type: boolean
+        default: false
+      vault_mode:
+        required: false
+        type: string
+        default: "none"
+      vault_addr:
+        required: false
+        type: string
+        default: "https://vault.maestra.io"
+      teleport_app:
+        required: false
+        type: string
+        default: ""
+      vault_role:
+        required: false
+        type: string
+        default: ""
+      vault_secrets:
+        required: false
+        type: string
+        default: ""
+      mint_proxmox_token:
+        required: false
+        type: boolean
+        default: false
+      extra_env:
+        required: false
+        type: string
+        default: ""
+      extra_run_args:
+        required: false
+        type: string
+        default: ""
+      no_hosts_fail_on_apply:
+        required: false
+        type: boolean
+        default: false
+      teleport_join_token:
+        required: false
+        type: string
+        default: "github-actions-infra-deploy"
+      teleport_fqdn:
+        required: false
+        type: string
+        default: "teleport.maestra.io:443"
+      requirements_pip:
+        required: false
+        type: string
+        default: "ansible/requirements-pip.txt"
+      requirements_galaxy:
+        required: false
+        type: string
+        default: "ansible/requirements.yml"
+      python_version:
+        required: false
+        type: string
+        default: "3.14"
+    secrets:
+      VECTOR_SIEM_BASIC_AUTH_USER:
+        required: false
+      VECTOR_SIEM_BASIC_AUTH_PASSWORD:
+        required: false
+      PROXMOX_MONITORING_PASSWORD:
+        required: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  run:
+    uses: ./.github/workflows/ansible-run.yml
+    secrets: inherit
+    with:
+      playbook: ${{ inputs.playbook }}
+      inventory: ${{ inputs.inventory }}
+      working_directory: ${{ inputs.working_directory }}
+      region: ${{ inputs.region }}
+      environment: ${{ inputs.environment }}
+      site: ${{ inputs.site }}
+      inventory_group_suffix: ${{ inputs.inventory_group_suffix }}
+      check_mode: ${{ inputs.check_mode }}
+      verbosity: ${{ inputs.verbosity }}
+      host_limit: ${{ inputs.host_limit }}
+      tags: ${{ inputs.tags }}
+      use_mitogen: ${{ inputs.use_mitogen }}
+      windows_mode: ${{ inputs.windows_mode }}
+      vault_mode: ${{ inputs.vault_mode }}
+      vault_addr: ${{ inputs.vault_addr }}
+      teleport_app: ${{ inputs.teleport_app }}
+      vault_role: ${{ inputs.vault_role }}
+      vault_secrets: ${{ inputs.vault_secrets }}
+      mint_proxmox_token: ${{ inputs.mint_proxmox_token }}
+      extra_env: ${{ inputs.extra_env }}
+      extra_run_args: ${{ inputs.extra_run_args }}
+      no_hosts_fail_on_apply: ${{ inputs.no_hosts_fail_on_apply }}
+      teleport_join_token: ${{ inputs.teleport_join_token }}
+      teleport_fqdn: ${{ inputs.teleport_fqdn }}
+      requirements_pip: ${{ inputs.requirements_pip }}
+      requirements_galaxy: ${{ inputs.requirements_galaxy }}
+      python_version: ${{ inputs.python_version }}
+      # Approval gate only for omega; omicron passes '' (ungated).
+      gh_environment: ${{ inputs.environment == 'omega' && format('{0}-{1}-{2}', inputs.region, inputs.environment, inputs.site) || '' }}

--- a/.github/workflows/ansible-pr.yml
+++ b/.github/workflows/ansible-pr.yml
@@ -1,0 +1,244 @@
+# maestra-io/github-actions/.github/workflows/ansible-pr.yml
+#
+# Reusable PR workflow: lint -> check-mode matrix (fan-out to ansible-run) -> unified PR comment.
+#
+# The caller passes:
+#   - `envs`: a JSON array of {region,environment,site,inventory_group_suffix?,tags?,
+#             vault_mode?,vault_addr?,teleport_app?,vault_role?,vault_secrets?,
+#             mint_proxmox_token?,extra_run_args?,extra_env?} objects -> becomes the check matrix.
+#   - `playbook`, `use_mitogen`, `windows_mode`, etc. as shared defaults.
+#
+# Path convention: `playbook` / `inventory` / `lint_paths` are relative to `working_directory`.
+#
+# Standardized commenter flavor: FLAT plan-*.log + merge-multiple:true (the majority variant —
+# nat-gateway / vpn / mssql / ad / haproxy). Single sticky comment, marker <!-- ansible-plan-diff -->.
+# Log filenames carry the inventory_group_suffix (plan-<r>-<e>-<s><suffix>.log), so per-role
+# rows (e.g. haproxy _haproxy_public vs _haproxy_api) each get their own table row; the
+# commenter's parsing is prefix/extension stripping, so any suffix is tolerated.
+name: Ansible PR (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      envs:
+        description: "JSON array of per-env objects for the check matrix"
+        required: true
+        type: string
+      playbook:
+        required: true
+        type: string
+      inventory:
+        description: "Inventory path relative to working_directory"
+        required: false
+        type: string
+        default: "inventory/teleport_inventory.py"
+      working_directory:
+        required: false
+        type: string
+        default: "ansible"
+      use_mitogen:
+        required: false
+        type: boolean
+        default: true
+      windows_mode:
+        required: false
+        type: boolean
+        default: false
+      lint_paths:
+        description: "Paths passed to ansible-lint / yamllint, relative to working_directory"
+        required: false
+        type: string
+        default: "."
+      requirements_lint:
+        required: false
+        type: string
+        default: "ansible/requirements-lint.txt"
+      requirements_pip:
+        required: false
+        type: string
+        default: "ansible/requirements-pip.txt"
+      requirements_galaxy:
+        required: false
+        type: string
+        default: "ansible/requirements.yml"
+      python_version:
+        required: false
+        type: string
+        default: "3.14"
+      teleport_join_token:
+        required: false
+        type: string
+        default: "github-actions-infra-deploy"
+      teleport_fqdn:
+        required: false
+        type: string
+        default: "teleport.maestra.io:443"
+      extra_env:
+        description: "Extra KEY=VALUE lines for the Execute env (workflow-wide default; per-row extra_env in `envs` wins)"
+        required: false
+        type: string
+        default: ""
+      extra_run_args:
+        description: "Extra ansible-playbook args (workflow-wide default; per-row extra_run_args in `envs` wins)"
+        required: false
+        type: string
+        default: ""
+      no_hosts_fail_on_apply:
+        required: false
+        type: boolean
+        default: false
+      comment_max_chars:
+        description: "Max characters of log tail included per env section in the PR comment"
+        required: false
+        type: string
+        default: "4000"
+    secrets:
+      VECTOR_SIEM_BASIC_AUTH_USER:
+        required: false
+      VECTOR_SIEM_BASIC_AUTH_PASSWORD:
+        required: false
+      PROXMOX_MONITORING_PASSWORD:
+        required: false
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6 # TODO: SHA-pin via Renovate on landing
+      - uses: astral-sh/setup-uv@v8.2.0 # TODO: SHA-pin via Renovate on landing
+        with:
+          python-version: ${{ inputs.python_version }}
+      - name: Install lint deps
+        run: uv pip install --system ansible -r "${{ inputs.requirements_lint }}"
+      - name: Cache Ansible Galaxy collections
+        uses: actions/cache@v6 # TODO: SHA-pin via Renovate on landing
+        with:
+          path: ~/.ansible/collections
+          key: galaxy-${{ runner.os }}-${{ hashFiles(inputs.requirements_galaxy) }}
+      - name: Install Galaxy collections/roles
+        if: ${{ hashFiles(inputs.requirements_galaxy) != '' }}
+        run: ansible-galaxy collection install -r "${{ inputs.requirements_galaxy }}" || true
+      - name: yamllint
+        working-directory: ${{ inputs.working_directory }}
+        run: yamllint ${{ inputs.lint_paths }}
+      - name: ansible-lint
+        working-directory: ${{ inputs.working_directory }}
+        run: ansible-lint ${{ inputs.lint_paths }}
+
+  check:
+    needs: lint
+    strategy:
+      fail-fast: false
+      matrix:
+        env: ${{ fromJSON(inputs.envs) }}
+    uses: ./.github/workflows/ansible-run.yml
+    secrets: inherit
+    with:
+      playbook: ${{ inputs.playbook }}
+      inventory: ${{ inputs.inventory }}
+      working_directory: ${{ inputs.working_directory }}
+      region: ${{ matrix.env.region }}
+      environment: ${{ matrix.env.environment }}
+      site: ${{ matrix.env.site }}
+      inventory_group_suffix: ${{ matrix.env.inventory_group_suffix || '' }}
+      tags: ${{ matrix.env.tags || '' }}
+      check_mode: true
+      use_mitogen: ${{ inputs.use_mitogen }}
+      windows_mode: ${{ inputs.windows_mode }}
+      vault_mode: ${{ matrix.env.vault_mode || 'none' }}
+      vault_addr: ${{ matrix.env.vault_addr || 'https://vault.maestra.io' }}
+      teleport_app: ${{ matrix.env.teleport_app || '' }}
+      vault_role: ${{ matrix.env.vault_role || '' }}
+      vault_secrets: ${{ matrix.env.vault_secrets || '' }}
+      mint_proxmox_token: ${{ matrix.env.mint_proxmox_token || false }}
+      extra_env: ${{ matrix.env.extra_env || inputs.extra_env }}
+      extra_run_args: ${{ matrix.env.extra_run_args || inputs.extra_run_args }}
+      no_hosts_fail_on_apply: ${{ inputs.no_hosts_fail_on_apply }}
+      teleport_join_token: ${{ inputs.teleport_join_token }}
+      teleport_fqdn: ${{ inputs.teleport_fqdn }}
+      requirements_pip: ${{ inputs.requirements_pip }}
+      requirements_galaxy: ${{ inputs.requirements_galaxy }}
+      python_version: ${{ inputs.python_version }}
+      artifact_name: ansible-check-${{ matrix.env.region }}-${{ matrix.env.environment }}-${{ matrix.env.site }}${{ matrix.env.inventory_group_suffix || '' }}
+
+  comment:
+    needs: check
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all check logs (flat)
+        uses: actions/download-artifact@v8 # TODO: SHA-pin via Renovate on landing
+        with:
+          pattern: ansible-check-*
+          merge-multiple: true
+          path: logs
+      - name: Upsert plan-diff comment
+        uses: actions/github-script@v9 # TODO: SHA-pin via Renovate on landing
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const MARKER = '<!-- ansible-plan-diff -->';
+            const MAX_PER_ENV = parseInt('${{ inputs.comment_max_chars }}', 10) || 4000;
+            const logsDir = 'logs';
+
+            const stripAnsi = (s) => s.replace(/\x1b\[[0-9;]*m/g, '');
+            const count = (s, re) => { const m = s.match(re); return m ? m.length : 0; };
+
+            let files = [];
+            try {
+              files = fs.readdirSync(logsDir)
+                .filter(f => f.startsWith('plan-') && f.endsWith('.log'));
+            } catch (e) { files = []; }
+
+            const rows = [];
+            const sections = [];
+            for (const f of files.sort()) {
+              const raw = stripAnsi(fs.readFileSync(path.join(logsDir, f), 'utf8'));
+              // filename = plan-<region>-<env>-<site><suffix>.log; the whole middle
+              // (incl. any inventory_group_suffix) becomes the row label.
+              const env = f.replace(/^plan-/, '').replace(/\.log$/, '');
+              const noHosts = /No hosts matched/i.test(raw);
+              const changed = count(raw, /changed=[1-9]/g);
+              const failed  = count(raw, /failed=[1-9]/g);
+              const unreach = count(raw, /unreachable=[1-9]/g);
+
+              let status;
+              if (noHosts) status = '⏭️ no hosts';
+              else if (failed || unreach) status = '❌ failed';
+              else if (changed) status = '📝 changes';
+              else status = '✅ no changes';
+
+              rows.push(`| \`${env}\` | ${status} | changed=${changed} failed=${failed} unreachable=${unreach} |`);
+
+              const hasChanges = changed > 0;
+              const hasFailed = failed > 0 || unreach > 0;
+              if (hasChanges || hasFailed) {
+                const body = raw.length > MAX_PER_ENV
+                  ? raw.slice(-MAX_PER_ENV) + '\n... (truncated)'
+                  : raw;
+                sections.push(`<details><summary>${env} — ${status}</summary>\n\n\`\`\`\n${body}\n\`\`\`\n</details>`);
+              }
+            }
+
+            const table = rows.length
+              ? ['| env | status | recap |', '| --- | --- | --- |', ...rows].join('\n')
+              : '_No ansible check logs found._';
+
+            const commentBody =
+              `${MARKER}\n## Ansible plan (check mode)\n\n${table}\n\n${sections.join('\n\n')}`;
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.find(c => c.body && c.body.includes(MARKER));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: commentBody });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body: commentBody });
+            }

--- a/.github/workflows/ansible-run.yml
+++ b/.github/workflows/ansible-run.yml
@@ -1,0 +1,399 @@
+# maestra-io/github-actions/.github/workflows/ansible-run.yml
+#
+# Generic reusable Ansible runner. Covers EVERY consumer's run path:
+#   - Teleport auth (dynamic version discovery + binary cache)
+#   - Mitogen (Linux) OR linear/no-mitogen (Windows-over-SSH)
+#   - Vault: none | public (vault.maestra.io direct, JWT) | tunnel (tbot app-tunnel -> 127.0.0.1:8200)
+#   - Generic Vault secret map (multiline, passed straight to vault-action's `secrets:`)
+#   - Optional proxmox pveum API-token mint/cleanup (input-gated; inert for the other 6 repos)
+#   - No-hosts graceful-skip guard (sentinel log), log capture, artifact upload, step summary
+#
+# Path convention: `playbook` and `inventory` are relative to `working_directory`
+# (the Execute step runs with working-directory = inputs.working_directory).
+# `requirements_pip` / `requirements_galaxy` are workspace-root-relative (installed
+# before we cd into working_directory).
+name: Ansible Run (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      # --- what to run ---------------------------------------------------
+      playbook:
+        description: "Playbook path relative to working_directory, e.g. playbooks/nat-gateway.yml"
+        required: true
+        type: string
+      inventory:
+        description: "Inventory path relative to working_directory (dynamic teleport script or static hosts.yml)"
+        required: false
+        type: string
+        default: "inventory/teleport_inventory.py"
+      working_directory:
+        description: "Directory to run ansible from (holds ansible.cfg)"
+        required: false
+        type: string
+        default: "ansible"
+      # --- 3-axis targeting ----------------------------------------------
+      region:
+        required: true
+        type: string
+      environment:
+        required: true
+        type: string
+      site:
+        required: true
+        type: string
+      inventory_group_suffix:
+        description: "Suffix appended to <region>_<env>_<site> to form the inventory group / --limit (e.g. _nat_gateway, _vpn, _sql, _dc, _haproxy_public). Empty = bare triple."
+        required: false
+        type: string
+        default: ""
+      host_limit:
+        description: "Explicit --limit override; when set it wins over the computed group."
+        required: false
+        type: string
+        default: ""
+      tags:
+        description: "Comma-separated ansible --tags"
+        required: false
+        type: string
+        default: ""
+      verbosity:
+        description: "normal | -v | -vv | -vvv"
+        required: false
+        type: string
+        default: "normal"
+      check_mode:
+        required: false
+        type: boolean
+        default: false
+      # --- execution mode ------------------------------------------------
+      use_mitogen:
+        description: "Enable Mitogen linear strategy (Linux). Set false for Windows/PowerShell-over-SSH."
+        required: false
+        type: boolean
+        default: true
+      windows_mode:
+        description: "Windows-over-SSH target: forces linear strategy + host_key_checking off."
+        required: false
+        type: boolean
+        default: false
+      # --- vault ---------------------------------------------------------
+      vault_mode:
+        description: "none | public | tunnel"
+        required: false
+        type: string
+        default: "none"
+      vault_addr:
+        description: "Vault address (public mode: https://vault.maestra.io; tunnel mode: http://127.0.0.1:8200)"
+        required: false
+        type: string
+        default: "https://vault.maestra.io"
+      teleport_app:
+        description: "Teleport app name for the tbot Vault tunnel (tunnel mode only, e.g. vault-omicron). Empty = no tunnel."
+        required: false
+        type: string
+        default: ""
+      vault_role:
+        description: "Vault JWT role name (auth method jwt-github)"
+        required: false
+        type: string
+        default: ""
+      vault_secrets:
+        description: "Multiline map passed verbatim to hashicorp/vault-action `secrets:` (e.g. 'infrastructure/data/x field | ENV_NAME')"
+        required: false
+        type: string
+        default: ""
+      # --- proxmox-only optional pre-step (divergence class 1) -----------
+      mint_proxmox_token:
+        description: "Mint a per-run Proxmox pveum API token via tsh ssh (proxmox repo only)."
+        required: false
+        type: boolean
+        default: false
+      # --- misc ----------------------------------------------------------
+      extra_env:
+        description: "Extra KEY=VALUE lines injected into the Execute step env (may reference secrets already exported to \\$GITHUB_ENV)."
+        required: false
+        type: string
+        default: ""
+      extra_run_args:
+        description: "Extra args appended to ansible-playbook (e.g. -e vault_consul_template_token=... for haproxy CDP)."
+        required: false
+        type: string
+        default: ""
+      gh_environment:
+        description: "GitHub Environment for the approval gate; empty = ungated."
+        required: false
+        type: string
+        default: ""
+      artifact_name:
+        description: "Name of the uploaded plan/apply log artifact."
+        required: false
+        type: string
+        default: ""
+      teleport_join_token:
+        required: false
+        type: string
+        default: "github-actions-infra-deploy"
+      teleport_fqdn:
+        required: false
+        type: string
+        default: "teleport.maestra.io:443"
+      python_version:
+        required: false
+        type: string
+        default: "3.14"
+      requirements_pip:
+        required: false
+        type: string
+        default: "ansible/requirements-pip.txt"
+      requirements_galaxy:
+        required: false
+        type: string
+        default: "ansible/requirements.yml"
+      no_hosts_fail_on_apply:
+        description: "If true, an empty target group fails on apply (exit 1) but still skips on check_mode. mssql/ad want this."
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      # Optional GH-secret passthrough for repos that inject app creds into the run
+      # (proxmox VECTOR_SIEM_*/PROXMOX_MONITORING_PASSWORD). Harmlessly empty elsewhere.
+      VECTOR_SIEM_BASIC_AUTH_USER:
+        required: false
+      VECTOR_SIEM_BASIC_AUTH_PASSWORD:
+        required: false
+      PROXMOX_MONITORING_PASSWORD:
+        required: false
+
+permissions:
+  contents: read
+  id-token: write   # OIDC for Teleport join + Vault JWT
+
+jobs:
+  ansible:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.gh_environment }}
+    concurrency:
+      group: ansible-${{ inputs.region }}-${{ inputs.environment }}-${{ inputs.site }}${{ inputs.inventory_group_suffix }}
+      cancel-in-progress: false
+    env:
+      ANSIBLE_FORCE_COLOR: "1"
+      ANSIBLE_HOST_KEY_CHECKING: ${{ inputs.windows_mode && 'False' || 'True' }}
+      ANSIBLE_STRATEGY: ${{ (inputs.use_mitogen && !inputs.windows_mode) && 'mitogen_linear' || 'linear' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6 # TODO: SHA-pin via Renovate on landing
+
+      - name: Set up Python + uv
+        uses: astral-sh/setup-uv@v8.2.0 # TODO: SHA-pin via Renovate on landing
+        with:
+          python-version: ${{ inputs.python_version }}
+
+      - name: Install ansible + pip requirements
+        run: uv pip install --system -r "${{ inputs.requirements_pip }}"
+
+      - name: Cache Ansible Galaxy collections
+        uses: actions/cache@v6 # TODO: SHA-pin via Renovate on landing
+        with:
+          path: ~/.ansible/collections
+          key: galaxy-${{ runner.os }}-${{ hashFiles(inputs.requirements_galaxy) }}
+
+      - name: Install Galaxy collections/roles
+        if: ${{ hashFiles(inputs.requirements_galaxy) != '' }}
+        run: ansible-galaxy install -r "${{ inputs.requirements_galaxy }}" || true
+
+      - name: Get Teleport version from proxy
+        id: tp-version
+        run: |
+          VER="$(/usr/bin/curl -sf "https://${{ inputs.teleport_fqdn }}/webapi/find" \
+            | jq -r '.auto_update.tools_version // .server_version')"
+          echo "version=${VER}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Teleport binaries
+        uses: actions/cache@v6 # TODO: SHA-pin via Renovate on landing
+        with:
+          path: ${{ runner.tool_cache }}/teleport
+          key: teleport-${{ runner.os }}-${{ runner.arch }}-${{ steps.tp-version.outputs.version }}
+
+      - name: Setup Teleport
+        uses: teleport-actions/setup@v1 # TODO: SHA-pin via Renovate on landing
+        with:
+          version: ${{ steps.tp-version.outputs.version }}
+
+      - name: Teleport auth (SSH)
+        uses: teleport-actions/auth@v2 # TODO: SHA-pin via Renovate on landing
+        with:
+          proxy: ${{ inputs.teleport_fqdn }}
+          token: ${{ inputs.teleport_join_token }}
+          certificate-ttl: 1h
+
+      # --- Mitogen (Linux only) ------------------------------------------
+      - name: Configure Mitogen strategy plugin
+        if: ${{ inputs.use_mitogen && !inputs.windows_mode }}
+        run: |
+          PLUGINS="$(python3 -c 'import ansible_mitogen, os; print(os.path.join(ansible_mitogen.__path__[0], "plugins", "strategy"))')"
+          echo "ANSIBLE_STRATEGY_PLUGINS=${PLUGINS}" >> "$GITHUB_ENV"
+
+      # --- Vault: tunnel mode (mssql/ad omicron) -------------------------
+      - name: Start Vault tunnel via Teleport
+        id: vault-tunnel
+        if: ${{ inputs.vault_mode == 'tunnel' && inputs.teleport_app != '' }}
+        run: |
+          cat > /tmp/tbot-vault-config.yaml <<EOF
+          version: v2
+          onboarding:
+            join_method: github
+            token: ${{ inputs.teleport_join_token }}
+          proxy_server: ${{ inputs.teleport_fqdn }}
+          services:
+            - type: application-tunnel
+              app_name: ${{ inputs.teleport_app }}
+              listen: tcp://127.0.0.1:8200
+          EOF
+          tbot start -c /tmp/tbot-vault-config.yaml &
+          echo "tunnel_pid=$!" >> "$GITHUB_OUTPUT"
+          for i in $(seq 1 15); do
+            (echo > /dev/tcp/127.0.0.1/8200) >/dev/null 2>&1 && break
+            sleep 1
+          done
+
+      # --- Vault: fetch secrets (public OR tunnel) -----------------------
+      - name: Retrieve secrets from Vault
+        if: ${{ inputs.vault_mode != 'none' && inputs.vault_secrets != '' }}
+        uses: hashicorp/vault-action@v4 # TODO: SHA-pin via Renovate on landing
+        with:
+          url: ${{ inputs.vault_addr }}
+          method: jwt
+          path: jwt-github
+          role: ${{ inputs.vault_role }}
+          jwtGithubAudience: https://github.com/maestra-io
+          exportEnv: true
+          secrets: ${{ inputs.vault_secrets }}
+
+      # --- Proxmox pveum token (divergence class 1, input-gated) ---------
+      - name: Mint Proxmox API token
+        id: mint-proxmox
+        if: ${{ inputs.mint_proxmox_token }}
+        run: |
+          set -euo pipefail
+          # Pick a candidate proxmox node in this region/env/site and mint a github-ci token.
+          NODES="$(tsh ls --format=names \
+            "role=proxmox,region=${{ inputs.region }},environment=${{ inputs.environment }},site=${{ inputs.site }}" || true)"
+          TOKEN_VALUE=""
+          TOKEN_NODE=""
+          for NODE in $(echo "$NODES" | shuf); do
+            OUT="$(gtimeout 30 tsh ssh --login=teleport-production "$NODE" '
+              pveum user add ansible-ci@pve 2>/dev/null || true
+              pveum acl modify / -user ansible-ci@pve -role Administrator
+              pveum user token remove ansible-ci@pve github-ci 2>/dev/null || true
+              pveum user token add ansible-ci@pve github-ci --privsep=0 --output-format=json
+            ' 2>/dev/null || true)"
+            TOKEN="$(echo "$OUT" | jq -r '.value // empty' 2>/dev/null || true)"
+            if [ -n "$TOKEN" ]; then
+              TOKEN_VALUE="$TOKEN"
+              TOKEN_NODE="$NODE"
+              break
+            fi
+          done
+          if [ -z "$TOKEN_VALUE" ]; then
+            echo "::error::Failed to mint Proxmox token on any candidate node"
+            exit 1
+          fi
+          echo "::add-mask::$TOKEN_VALUE"
+          echo "PROXMOX_API_TOKEN_SECRET=$TOKEN_VALUE" >> "$GITHUB_ENV"
+          echo "node=$TOKEN_NODE" >> "$GITHUB_OUTPUT"
+
+      # --- Execute -------------------------------------------------------
+      - name: Execute Ansible
+        id: execute
+        working-directory: ${{ inputs.working_directory }}
+        env:
+          # optional app-cred passthroughs (empty for repos that don't set them)
+          VECTOR_SIEM_BASIC_AUTH_USER: ${{ secrets.VECTOR_SIEM_BASIC_AUTH_USER }}
+          VECTOR_SIEM_BASIC_AUTH_PASSWORD: ${{ secrets.VECTOR_SIEM_BASIC_AUTH_PASSWORD }}
+          PROXMOX_MONITORING_PASSWORD: ${{ secrets.PROXMOX_MONITORING_PASSWORD }}
+        run: |
+          set -uo pipefail
+
+          # inject caller-provided extra env
+          if [ -n "${{ inputs.extra_env }}" ]; then
+            while IFS= read -r line; do
+              [ -z "$line" ] && continue
+              export "$line"
+            done <<< "${{ inputs.extra_env }}"
+          fi
+
+          # check-mode display trim (matches source repos: hide ok/skipped hosts in plans)
+          if [ "${{ inputs.check_mode }}" = "true" ]; then
+            export ANSIBLE_DISPLAY_OK_HOSTS=false
+            export ANSIBLE_DISPLAY_SKIPPED_HOSTS=false
+          fi
+
+          # compute target group / --limit
+          LIMIT="${{ inputs.host_limit }}"
+          if [ -z "$LIMIT" ]; then
+            LIMIT="${{ inputs.region }}_${{ inputs.environment }}_${{ inputs.site }}${{ inputs.inventory_group_suffix }}"
+          fi
+
+          # verbosity
+          VERB="${{ inputs.verbosity }}"
+          [ "$VERB" = "normal" ] && VERB=""
+
+          # tags / check
+          TAGS_ARG=""; [ -n "${{ inputs.tags }}" ] && TAGS_ARG="--tags ${{ inputs.tags }}"
+          CHECK_ARG=""; [ "${{ inputs.check_mode }}" = "true" ] && CHECK_ARG="--check --diff"
+
+          MODE="apply"; [ "${{ inputs.check_mode }}" = "true" ] && MODE="plan"
+          SAFE_NAME="${{ inputs.region }}-${{ inputs.environment }}-${{ inputs.site }}${{ inputs.inventory_group_suffix }}"
+          mkdir -p "${{ github.workspace }}/logs"
+          LOG_FILE="${{ github.workspace }}/logs/${MODE}-${SAFE_NAME}.log"
+          echo "log_file=${LOG_FILE}" >> "$GITHUB_OUTPUT"
+
+          COMMON="-i ${{ inputs.inventory }} --limit ${LIMIT} ${TAGS_ARG} ${VERB} ${{ inputs.extra_run_args }}"
+
+          # no-hosts pre-flight guard
+          ansible-playbook ${{ inputs.playbook }} ${COMMON} --list-hosts > /tmp/list-hosts.txt 2>&1 || true
+          if grep -qiE 'no hosts (matched|to target)' /tmp/list-hosts.txt; then
+            echo "No hosts matched" | tee -a "$LOG_FILE"
+            if [ "${{ inputs.no_hosts_fail_on_apply }}" = "true" ] && [ "${{ inputs.check_mode }}" != "true" ]; then
+              exit 1
+            fi
+            exit 0
+          fi
+
+          set -o pipefail
+          ansible-playbook ${{ inputs.playbook }} ${COMMON} ${CHECK_ARG} 2>&1 | tee -a "$LOG_FILE"
+
+      # --- Vault tunnel teardown -----------------------------------------
+      - name: Stop Vault tunnel
+        if: ${{ always() && inputs.vault_mode == 'tunnel' && steps.vault-tunnel.outputs.tunnel_pid != '' }}
+        run: kill "${{ steps.vault-tunnel.outputs.tunnel_pid }}" || true
+
+      # --- Proxmox token cleanup -----------------------------------------
+      - name: Cleanup Proxmox API token
+        if: ${{ always() && inputs.mint_proxmox_token && steps.mint-proxmox.outputs.node != '' }}
+        run: |
+          gtimeout 30 tsh ssh --login=teleport-production "${{ steps.mint-proxmox.outputs.node }}" \
+            'pveum user token remove ansible-ci@pve github-ci' || true
+
+      - name: Generate summary
+        if: ${{ always() }}
+        run: |
+          {
+            echo "### Ansible ${{ inputs.check_mode && 'plan (check)' || 'apply' }} — ${{ inputs.region }}-${{ inputs.environment }}-${{ inputs.site }}${{ inputs.inventory_group_suffix }}"
+            echo ""
+            echo "| field | value |"
+            echo "| --- | --- |"
+            echo "| playbook | \`${{ inputs.playbook }}\` |"
+            echo "| limit | \`${{ inputs.host_limit || format('{0}_{1}_{2}{3}', inputs.region, inputs.environment, inputs.site, inputs.inventory_group_suffix) }}\` |"
+            echo "| tags | \`${{ inputs.tags }}\` |"
+            echo "| check_mode | ${{ inputs.check_mode }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload log artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7 # TODO: SHA-pin via Renovate on landing
+        with:
+          name: ${{ inputs.artifact_name != '' && inputs.artifact_name || format('ansible-check-{0}-{1}-{2}{3}', inputs.region, inputs.environment, inputs.site, inputs.inventory_group_suffix) }}
+          path: logs/
+          if-no-files-found: warn

--- a/docs/ansible-reusable-workflows.md
+++ b/docs/ansible-reusable-workflows.md
@@ -1,0 +1,250 @@
+# Ansible workflow consolidation — central reusable workflows
+
+Goal: kill the copy-paste of `ansible-run.yml` / `ansible-pr.yml` / `ansible-manual.yml` /
+`deploy.yml` across 7 repos by hosting **reusable workflows** in `maestra-io/github-actions`
+(which today holds only composite actions). Each consumer keeps a thin caller (~15-30 lines) that
+passes only its own constants (playbook, env matrix, mitogen flag, vault map).
+
+Central files (in `maestra-io/github-actions/.github/workflows/`):
+
+| file | kind | role |
+| --- | --- | --- |
+| `ansible-run.yml` | `workflow_call` | the generic runner (setup → teleport → mitogen → vault → execute → artifact) |
+| `ansible-pr.yml` | `workflow_call` | lint + check-mode matrix (fans out to `ansible-run.yml`) + **one** unified PR commenter |
+| `ansible-manual.yml` | `workflow_call` | single manual apply/check leg with the omega-only gate rule |
+| `ansible-deploy.yml` | `workflow_call` | single on-merge **apply** leg with the omega-only gate rule |
+
+The bespoke terraform↔ansible **ordering** (detect-changes, `terraform-run.yml`,
+`teleport-register-run.yml`, strict `needs`/`if` chains) stays in each repo's `deploy.yml`;
+only the ansible bodies are deduplicated. This keeps the cross-tool `needs` graph where it belongs.
+
+---
+
+## `ansible-run.yml` input contract
+
+**Path convention**: the Execute step runs with `working-directory: <working_directory>`
+(default `ansible/`), so **`playbook` and `inventory` are `working_directory`-relative** —
+`playbooks/nat-gateway.yml`, `inventory/teleport_inventory.py`, `inventory/hosts.yml`.
+Never prefix them with `ansible/`. Only `requirements_pip` / `requirements_galaxy` /
+`requirements_lint` are workspace-root-relative (they're consumed before the cd).
+
+| input | type | required | default | purpose |
+| --- | --- | --- | --- | --- |
+| `playbook` | string | yes | — | playbook path relative to `working_directory`, e.g. `playbooks/nat-gateway.yml` |
+| `inventory` | string | no | `inventory/teleport_inventory.py` | relative to `working_directory`; dynamic teleport script OR static `hosts.yml` |
+| `working_directory` | string | no | `ansible` | dir holding `ansible.cfg` |
+| `region` / `environment` / `site` | string | yes | — | 3-axis targeting triple |
+| `inventory_group_suffix` | string | no | `""` | appended to `<region>_<env>_<site>` to build the `--limit` group (`_nat_gateway`, `_vpn`, `_sql`, `_dc`, `_haproxy_public`, …) |
+| `host_limit` | string | no | `""` | explicit `--limit` override (wins over the computed group) |
+| `tags` | string | no | `""` | ansible `--tags` |
+| `verbosity` | string | no | `normal` | `normal` / `-v` / `-vv` / `-vvv` |
+| `check_mode` | boolean | no | `false` | `--check --diff` |
+| `use_mitogen` | boolean | no | `true` | Linux Mitogen linear strategy + runtime plugin-path step |
+| `windows_mode` | boolean | no | `false` | forces `linear` + `ANSIBLE_HOST_KEY_CHECKING=False` for PowerShell-over-SSH |
+| `vault_mode` | string | no | `none` | `none` / `public` / `tunnel` |
+| `vault_addr` | string | no | `https://vault.maestra.io` | public → vault.maestra.io; tunnel → `http://127.0.0.1:8200` |
+| `teleport_app` | string | no | `""` | tbot app-tunnel name (tunnel mode, e.g. `vault-omicron`); empty → no tunnel |
+| `vault_role` | string | no | `""` | Vault JWT role (`jwt-github`) |
+| `vault_secrets` | string (multiline) | no | `""` | passed **verbatim** to `hashicorp/vault-action` `secrets:` — the whole per-repo secret map |
+| `mint_proxmox_token` | boolean | no | `false` | proxmox-only pveum token mint + cleanup (input-gated) |
+| `extra_env` | string (multiline) | no | `""` | extra `KEY=VALUE` lines injected into the Execute env |
+| `extra_run_args` | string | no | `""` | extra `ansible-playbook` args (e.g. `-e vault_consul_template_token=…`) |
+| `gh_environment` | string | no | `""` | GitHub Environment approval gate; empty → ungated |
+| `artifact_name` | string | no | derived | plan/apply log artifact name (`ansible-check-<r>-<e>-<s><suffix>`) |
+| `teleport_join_token` | string | no | `github-actions-infra-deploy` | teleport join token |
+| `teleport_fqdn` | string | no | `teleport.maestra.io:443` | proxy (note: explicit :443) |
+| `python_version` | string | no | `3.14` | uv-installed python |
+| `requirements_pip` | string | no | `ansible/requirements-pip.txt` | run-time pip manifest |
+| `requirements_galaxy` | string | no | `ansible/requirements.yml` | galaxy manifest |
+| `no_hosts_fail_on_apply` | boolean | no | `false` | mssql/ad: empty group → fail on apply, skip on check |
+
+Optional passthrough **secrets** (declared `required:false`, harmlessly empty elsewhere):
+`VECTOR_SIEM_BASIC_AUTH_USER`, `VECTOR_SIEM_BASIC_AUTH_PASSWORD`, `PROXMOX_MONITORING_PASSWORD`
+— callers use `secrets: inherit`.
+
+Preserved behaviors (every consumer relies on ≥1): dynamic Teleport version discovery
+(`/webapi/find` → `auto_update.tools_version // server_version`) + version-keyed binary cache,
+galaxy collections cache, no-hosts graceful-skip sentinel (`No hosts matched`), flat
+`logs/plan|apply-<region>-<env>-<site><suffix>.log` capture (the `inventory_group_suffix` is part
+of the log filename AND the default artifact name, so multi-role repos like haproxy get one
+distinct row/artifact per role), check-mode display trim
+(`ANSIBLE_DISPLAY_OK_HOSTS=false` + `ANSIBLE_DISPLAY_SKIPPED_HOSTS=false`, check-mode only),
+`upload-artifact`, `GITHUB_STEP_SUMMARY` table, per-region-env-site-suffix `concurrency`
+(`cancel-in-progress:false`).
+
+### PR commenter — standardized on ONE flavor
+
+Both variants existed in the wild:
+- **flat `plan-*.log` + `merge-multiple:true`** — nat-gateway, vpn, mssql, ad, haproxy.
+- per-dir `readLog` + `merge-multiple:false` — proxmox, hyperv.
+
+The central `ansible-pr.yml` standardizes on the **flat `plan-*.log` + `merge-multiple:true`**
+flavor (`github-script@v9`, marker `<!-- ansible-plan-diff -->`, status table + gated
+`<details>` per changed/failed env, truncation via the `comment_max_chars` input, default
+`4000` chars per env section). proxmox + hyperv converge to it;
+no behavioral loss since both read the same `changed=/failed=/unreachable=` PLAY RECAP counters
+and the `No hosts matched` sentinel. Their callers just drop the old commenter.
+Row labels are derived from the log filename (`plan-<r>-<e>-<s><suffix>.log` → strip `plan-`
+prefix + `.log` extension), so per-row `inventory_group_suffix` values (haproxy roles) each
+produce their own table row.
+
+---
+
+## Per-repo caller mapping (all 7)
+
+Every caller is `uses: maestra-io/github-actions/.github/workflows/<x>.yml@<sha>` + `secrets: inherit`.
+
+### 1. maestra-nat-gateway (PILOT) — vault none, mitogen, 3-dim
+- **ansible-run.yml**: repo-local shim → central `ansible-run.yml`, pins
+  `playbook=playbooks/nat-gateway.yml`, `inventory_group_suffix=_nat_gateway`,
+  `use_mitogen=true`, `vault_mode=none`; inventory NOT passed (central default
+  `inventory/teleport_inventory.py` matches the repo layout).
+- **ansible-pr.yml**: central `ansible-pr.yml`, `envs=[us/omicron/lw, us/omega/lw,
+  eu/omega/lw{tags:netplan,frr}]` (eu group may be empty → no-hosts skip).
+- **ansible-manual.yml**: workflow_dispatch → local shim; omega-only gate.
+- **deploy.yml**: keeps `detect-changes` + `terraform-run.yml` interleave
+  (tf-omicron → ansible-omicron → tf-omega gate → ansible-omega gate); ansible legs call the
+  local shim with explicit `no_hosts_fail_on_apply=true`; **eu-omega has no auto-apply leg**.
+
+### 2. proxmox — vault public + **pveum token** (divergence class 1), mitogen
+- ansible-pr/manual/deploy call central reusables with `use_mitogen=true`,
+  `vault_mode=public`, `vault_role=proxmox-github-ci`,
+  `vault_secrets` = the OIDC pair from `infrastructure/data/proxmox/<region>-<env>/oidc`,
+  `mint_proxmox_token=true`, `extra_env`/secrets for
+  `VECTOR_SIEM_*` + `PROXMOX_MONITORING_PASSWORD`, **`inventory_group_suffix=''`** —
+  proxmox's limit group is the bare `<region>_<env>_<site>` triple (no `_proxmox` suffix
+  exists in its inventory).
+- deploy legs: us-omicron staging → (us-omega commented out) + eu-omega-lw, both need omicron.
+
+### 3. hyperv-maestra — vault none, **windows/no-mitogen**
+- `use_mitogen=false`, `windows_mode=true`, `vault_mode=none`,
+  `playbook=playbooks/hyperv.yml`. Only `us-omicron-lw` live (omega commented).
+- Fixes the inventory divergence at migration time (commit the teleport script OR point
+  `inventory` at the static `hosts.yml`).
+
+### 4. vpn-maestra — vault public, **5 conditional secret blocks**, mitogen, 3-dim (`_vpn`)
+- The 5 per-env `if:`-gated vault blocks collapse into ONE `vault_secrets` string that the
+  **caller computes per matrix row** (each env passes only the paths that exist for it).
+  Each row's `vault_secrets` map must include **ALL secrets the old per-env block fetched —
+  hub PSKs included** — reproducing the original env conditions 1:1. `vault-action` runs with
+  `exportEnv:true`, so every fetched secret lands in `GITHUB_ENV` and the playbook may consume
+  it via `lookup('env', ...)` even when no workflow line references it; dropping the hub-PSK
+  fetches would be an unproven-dead-code change and is NOT part of this migration.
+- `vault_role=vpn-maestra-github-ci`, suffix `_vpn`. PR matrix = the hand-listed 4 combos
+  (eu/omega/aws, us/omicron/lw, eu/omega/lw, us/omega/lw). deploy stays omicron-only /
+  POC-gated in the repo's own `deploy.yml`.
+
+### 5. mssql-maestra — **dual vault (tunnel/public)** (divergence class 3), windows, static inv
+- `use_mitogen=false`, `windows_mode=true`, `inventory=inventory/hosts.yml`, suffix `_sql`,
+  `no_hosts_fail_on_apply=true`, `playbook=playbooks/mssql.yml`.
+- The **caller computes vault routing per env**:
+  - omicron → `vault_mode=tunnel`, `vault_addr=http://127.0.0.1:8200`,
+    `teleport_app=vault-omicron`, `vault_role=mssql-maestra-deploy-github-ci`.
+  - omega → `vault_mode=public`, `vault_addr=https://vault.maestra.io`, `teleport_app=""`,
+    `vault_role=mssql-maestra-github-ci`.
+- 11-key AD/SQL `vault_secrets` map + `extra_env: OP_CONNECT_HOST=https://onepassword-connect.mindbox.cloud`.
+- `teleport-register-run.yml` pre-stage stays in the repo `deploy.yml`.
+
+### 6. active-directory-maestra — **dual vault (tunnel/public)**, windows, `_dc`
+- Same dual-routing pattern as mssql (roles `active-directory-maestra-deploy-github-ci`
+  omicron / `active-directory-maestra-github-ci` omega), `use_mitogen=false`,
+  `windows_mode=true`, suffix `_dc`, `playbook=playbooks/ad-dns-dhcp.yml`,
+  10-key `vault_secrets` from `infrastructure/active-directory/{domain-join,domain,mssql}`.
+- deploy.yml keeps asymmetric teleport-register gating (omega `==success`, omicron `!=failure`).
+
+### 7. haproxy-maestra — vault public + **consul-template token** (divergence class 2), mitogen, role-dim
+- `use_mitogen=true`, `vault_mode=public`, `vault_role=haproxy-maestra-github-ci`,
+  `playbook=playbooks/haproxy.yml`. The `role` input (`haproxy_public|private|api|cdp`)
+  becomes `inventory_group_suffix=_${role}`.
+- **consul-template token**: CDP+apply+`contains(tags,'consul-template')` only. The caller
+  passes `vault_secrets` = `github/data/common/VAULT_CONSUL_TEMPLATE_TOKEN_AZURE_PRODUCTION field
+  | CONSUL_TEMPLATE_VAULT_TOKEN` **and** `extra_run_args: -e vault_consul_template_token=…`
+  ONLY for the CDP row (other rows pass empty). `cdp-deploy.yml` stays a separate
+  dispatch-only canary caller.
+- `GH_TOKEN` for the `gh release download` of the haproxy-otel `.deb` is provided via
+  `extra_env: GH_TOKEN=${{ github.token }}` (or a job-level env in the caller).
+
+---
+
+## How the 3 divergence classes are handled
+
+1. **proxmox `pveum` API-token mint** — NOT a Vault fetch (it's `tsh ssh` + `pveum user/acl/token`
+   producing `PROXMOX_API_TOKEN_SECRET`, consumed **in the same job** by Execute; env can't cross
+   reusable boundaries). Handled as an **input-gated optional step** (`mint_proxmox_token: true`)
+   inside `ansible-run.yml` + its `always()` cleanup step. Inert (`if:` false) for the other 6
+   repos. Chosen over a divergent `ansible-run-proxmox.yml` fork so there's ONE runner; the step
+   is cleanly scoped by the boolean and touches nothing when off.
+
+2. **haproxy consul-template token** — this one IS a Vault fetch, so it needs **no special step**:
+   the caller puts the single KV line in `vault_secrets` and threads the value into the run via
+   `extra_run_args: -e vault_consul_template_token=…`, both supplied only for the CDP matrix row
+   (role-conditional + tags-conditional + apply-only gating lives in the caller's matrix, not the
+   generic workflow).
+
+3. **mssql / ad Vault-tunnel mode** — folded into `ansible-run.yml` via `vault_mode=tunnel` +
+   `teleport_app` + `vault_addr`. A `Start Vault tunnel` step (tbot v2 application-tunnel →
+   `127.0.0.1:8200`, gated `if: vault_mode=='tunnel' && teleport_app != ''`) and an `always()`
+   `Stop Vault tunnel` step wrap the generic `vault-action` fetch. Because the mode is a per-call
+   **input**, the dual omega-public/omicron-tunnel behavior inside ONE repo is expressed by the
+   **caller computing the routing per matrix row** — no second workflow, no divergent copy. (A
+   scoped `ansible-run-tunneled.yml` was considered and rejected: the tunnel is 2 guarded steps,
+   not enough surface to justify a fork, and a fork couldn't express the per-env dual mode without
+   the caller branching anyway.)
+
+---
+
+## Caller wiring checklist (sharp edges — verify per consumer before merge)
+
+- **AD dual-vault per-row wiring** (active-directory-maestra): each matrix row / deploy leg
+  carries its OWN vault routing —
+  omicron: `vault_mode=tunnel`, `teleport_app=vault-omicron`, `vault_addr=http://127.0.0.1:8200`,
+  `vault_role=active-directory-maestra-deploy-github-ci`;
+  omega: `vault_mode=public`, `vault_addr=https://vault.maestra.io`, `teleport_app=''`,
+  `vault_role=active-directory-maestra-github-ci`. Never share one vault block across rows.
+- **`no_hosts_fail_on_apply=true` is REQUIRED on every mssql/AD apply leg** (deploy + manual
+  apply). Their empty-group condition is an error on apply (host lost from static inventory),
+  only a skip on check.
+- **haproxy consul-template fetch is caller-gated to non-check CDP runs only**: the CDP apply
+  row passes `vault_secrets` = the `VAULT_CONSUL_TEMPLATE_TOKEN_AZURE_PRODUCTION | CONSUL_TEMPLATE_VAULT_TOKEN`
+  line AND `extra_run_args` = the **literal string**
+  `-e vault_consul_template_token=$CONSUL_TEMPLATE_VAULT_TOKEN`
+  (single-quoted in YAML; the runner's Execute shell expands it AFTER vault-action exported the
+  env var — do NOT try to interpolate it in workflow expressions). Check-mode CDP rows and all
+  non-CDP rows pass **empty `vault_secrets`** (and no extra_run_args).
+- **hyperv**: set `requirements_galaxy` to its real manifest path (or commit one — the repo has
+  none today), and resolve its inventory divergence BEFORE migrating: the teleport dynamic
+  inventory script is **not committed** in hyperv-maestra, so either commit it or pass
+  `inventory=inventory/hosts.yml` (static).
+- **`lint_paths` override** for repos without `roles/`: the default is `.`
+  (working_directory-relative); repos whose ansible tree would make `.` too noisy can pass
+  e.g. `lint_paths=playbooks/` — both yamllint and ansible-lint run from `working_directory`,
+  so the same relative paths feed both tools.
+- **proxmox** passes `inventory_group_suffix=''` (bare triple limit group, see above).
+- **vpn** reproduces ALL original per-env vault fetches incl. hub PSKs (see above).
+
+## Action pinning — SHA pinning is the decided policy
+
+- Third-party actions inside the central workflows are currently written as
+  `owner/action@vX` tags with a `# TODO: SHA-pin via Renovate on landing` comment. **On landing
+  in `maestra-io/github-actions` they MUST be converted to full-SHA pins** (`owner/action@<sha>
+  # vX.Y.Z`); Renovate's `github-actions` manager then keeps the SHAs bumped. Tag-pinned
+  consumers (proxmox/hyperv/mssql/ad/haproxy) inherit the central SHA pins for free once
+  migrated.
+- Callers **SHA-pin the central ref**:
+  `uses: maestra-io/github-actions/.github/workflows/<x>.yml@<full-sha> # renovate: maestra-io/github-actions`
+  (the `@0000…0000` placeholders in the nat-gateway drafts). Renovate's `github-actions`
+  manager natively bumps SHA-pinned `uses:` refs of reusable workflows; the `# renovate:`
+  comment keeps the mapping explicit. SHA pinning (not tag pinning) of the central ref is the
+  decided policy — a moving tag on the workflow that holds Teleport/Vault auth would be a
+  supply-chain hole.
+
+## Backward-compatibility checklist (per consumer, before merge)
+
+- [ ] inventory: teleport script committed (hyperv) or `inventory` input points at the real path.
+- [ ] `requirements_pip` vs `requirements_lint` filenames match the repo (both are inputs).
+- [ ] windows repos set `use_mitogen=false` + `windows_mode=true`.
+- [ ] dual-vault repos compute `vault_mode`/`vault_addr`/`teleport_app`/`vault_role` per matrix row.
+- [ ] `no_hosts_fail_on_apply=true` only for mssql/ad (asymmetric exit).
+- [ ] omega-only gate preserved (`gh_environment` derivation), omicron ungated.
+- [ ] `deploy.yml` terraform/teleport-register ordering + POC `if:` gates left untouched in-repo.
+- [ ] PR commenter converged to the flat flavor (proxmox/hyperv drop the per-dir readLog).


### PR DESCRIPTION
## What

Central **reusable workflows** for the Ansible CI/CD family that is currently copy-pasted (~1000 lines each set, already drifting into two variants) across 7 repos: `maestra-nat-gateway`, `proxmox`, `hyperv-maestra`, `vpn-maestra`, `mssql-maestra`, `active-directory-maestra`, `haproxy-maestra`.

| file | kind | role |
| --- | --- | --- |
| `.github/workflows/ansible-run.yml` | `workflow_call` | generic runner: uv/py → galaxy cache → Teleport OIDC (dynamic version discovery + cache) → optional Mitogen → Vault `none/public/tunnel` → optional proxmox pveum token mint → execute (no-hosts guard) → artifact + summary |
| `.github/workflows/ansible-pr.yml` | `workflow_call` | lint + check-mode env matrix (fans out to ansible-run) + unified sticky PR plan/diff commenter |
| `.github/workflows/ansible-manual.yml` | `workflow_call` | manual apply/check leg, omega-only environment gate rule |
| `.github/workflows/ansible-deploy.yml` | `workflow_call` | on-merge apply leg, omega-only environment gate rule |
| `docs/ansible-reusable-workflows.md` | doc | input contract + per-repo caller mapping for all 7 + caller wiring checklist |

All per-repo variation is inputs: `playbook`, `inventory_group_suffix` (haproxy roles get distinct log/artifact names → no upload collisions), `vault_mode`/`vault_secrets` (verbatim map incl. mssql/AD tunnel mode via tbot app-tunnel), `windows_mode`, `use_mitogen`, `extra_env`/`extra_run_args`, `no_hosts_fail_on_apply`, `comment_max_chars`.

## Why

One fix (action bump, Teleport auth change, commenter fix) currently needs 7 synchronized edits and in practice lands in 1-2 repos → drift. The two commenter variants in the wild are already ~200 diverged lines of the same original.

## Rollout

Consumers keep thin (~15-30 line) callers pinned by **commit SHA** to this repo; Renovate's `github-actions` manager bumps the pin. Pilot: `maestra-nat-gateway` (PR follows after this merges — its check-mode PR run is the end-to-end validation). Then the remaining 6, then the same pattern for the terraform-* family.

Design was cross-checked per consumer (all 7 repos' current workflows harvested and diffed against this contract; wiring hazards captured in the doc's caller checklist).

Validation: `actionlint` clean (only intentional shellcheck style suppressions), YAML parse clean on all files. Reusable `workflow_call` files don't execute in this repo's own CI; first execution is the pilot's read-only `--check --diff` PR run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)