### PR TITLE
Fix lint/runner python: setup-python before setup-uv

### DIFF
--- a/.github/workflows/ansible-pr.yml
+++ b/.github/workflows/ansible-pr.yml
@@ -110,9 +110,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6 # TODO: SHA-pin via Renovate on landing
-      - uses: astral-sh/setup-uv@v8.2.0 # TODO: SHA-pin via Renovate on landing
+      - uses: actions/setup-python@v6 # TODO: SHA-pin via Renovate on landing
         with:
           python-version: ${{ inputs.python_version }}
+      - uses: astral-sh/setup-uv@v8.2.0 # TODO: SHA-pin via Renovate on landing
+        with:
+          enable-cache: true
       - name: Install lint deps
         run: uv pip install --system ansible -r "${{ inputs.requirements_lint }}"
       - name: Cache Ansible Galaxy collections

--- a/.github/workflows/ansible-run.yml
+++ b/.github/workflows/ansible-run.yml
@@ -184,10 +184,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6 # TODO: SHA-pin via Renovate on landing
 
-      - name: Set up Python + uv
-        uses: astral-sh/setup-uv@v8.2.0 # TODO: SHA-pin via Renovate on landing
+      - name: Set up Python
+        uses: actions/setup-python@v6 # TODO: SHA-pin via Renovate on landing
         with:
           python-version: ${{ inputs.python_version }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.2.0 # TODO: SHA-pin via Renovate on landing
+        with:
+          enable-cache: true
 
       - name: Install ansible + pip requirements
         run: uv pip install --system -r "${{ inputs.requirements_pip }}"


### PR DESCRIPTION
`uv pip install --system` requires a **system** Python matching `UV_PYTHON`; `setup-uv`'s `python-version` input provisions a uv-managed interpreter, which `--system` refuses:

```
error: No system Python installation found for Python 3.14
```

Caught by the pilot's first live run ([maestra-nat-gateway#165](https://github.com/maestra-io/maestra-nat-gateway/pull/165), `pr / lint` red). Fix restores the source repos' proven order in both `ansible-run.yml` and `ansible-pr.yml`: `actions/setup-python@v6` (puts 3.14 on PATH) → `setup-uv` with `enable-cache` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)