### PR TITLE
Disable ANSIBLE_HOST_KEY_CHECKING unconditionally

### DIFF
--- a/.github/workflows/ansible-run.yml
+++ b/.github/workflows/ansible-run.yml
@@ -178,7 +178,9 @@ jobs:
       cancel-in-progress: false
     env:
       ANSIBLE_FORCE_COLOR: "1"
-      ANSIBLE_HOST_KEY_CHECKING: ${{ inputs.windows_mode && 'False' || 'True' }}
+      # All source repos ran with host key checking off: hosts are reached via
+      # ephemeral tsh ProxyCommand and CI runners never hold host keys.
+      ANSIBLE_HOST_KEY_CHECKING: "False"
       ANSIBLE_STRATEGY: ${{ (inputs.use_mitogen && !inputs.windows_mode) && 'mitogen_linear' || 'linear' }}
     steps:
       - name: Checkout


### PR DESCRIPTION
All 7 source repos run `ANSIBLE_HOST_KEY_CHECKING: 'False'` globally — hosts are reached via ephemeral `tsh` ProxyCommand and CI runners never hold host keys. The central runner made it `windows_mode`-conditional, which broke every Linux check job on the pilot ([maestra-nat-gateway#165](https://github.com/maestra-io/maestra-nat-gateway/pull/165)): `Host key checking is enabled...` → `UNREACHABLE` on all hosts in all 3 envs.

One-line fix: unconditional `"False"`, matching current production behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)