### PR TITLE
proxmox mint: sudo pveum + cleanup timeout (not gtimeout)

### DIFF
--- a/.github/workflows/ansible-run.yml
+++ b/.github/workflows/ansible-run.yml
@@ -294,10 +294,10 @@ jobs:
           TOKEN_NODE=""
           for NODE in $(echo "$NODES" | shuf); do
             OUT="$(timeout 30 tsh ssh --login=teleport-production "$NODE" '
-              pveum user add ansible-ci@pve 2>/dev/null || true
-              pveum acl modify / -user ansible-ci@pve -role Administrator
-              pveum user token remove ansible-ci@pve github-ci 2>/dev/null || true
-              pveum user token add ansible-ci@pve github-ci --privsep=0 --output-format=json
+              sudo pveum user add ansible-ci@pve 2>/dev/null || true
+              sudo pveum acl modify / -user ansible-ci@pve -role Administrator
+              sudo pveum user token remove ansible-ci@pve github-ci 2>/dev/null || true
+              sudo pveum user token add ansible-ci@pve github-ci --privsep=0 --output-format=json
             ' 2>/dev/null || true)"
             TOKEN="$(echo "$OUT" | jq -r '.value // empty' 2>/dev/null || true)"
             if [ -n "$TOKEN" ]; then
@@ -391,8 +391,8 @@ jobs:
       - name: Cleanup Proxmox API token
         if: ${{ always() && inputs.mint_proxmox_token && steps.mint-proxmox.outputs.node != '' }}
         run: |
-          gtimeout 30 tsh ssh --login=teleport-production "${{ steps.mint-proxmox.outputs.node }}" \
-            'pveum user token remove ansible-ci@pve github-ci' || true
+          timeout 30 tsh ssh --login=teleport-production "${{ steps.mint-proxmox.outputs.node }}" \
+            'sudo pveum user token remove ansible-ci@pve github-ci' || true
 
       - name: Generate summary
         if: ${{ always() }}


### PR DESCRIPTION
Two bugs in the input-gated proxmox token-mint path, caught during the `maestra-io/proxmox` migration review:

1. The source repo runs `sudo pveum ...` over `tsh ssh` (`teleport-production` is not root on pve nodes); the central mint dropped `sudo` → would fail on **every** candidate node, and the cleanup similarly.
2. The cleanup step still used `gtimeout` (macOS coreutils name) — `command not found` on ubuntu runners, silently swallowed by `|| true` → stale `github-ci` token would persist between runs.

Inert for all non-proxmox consumers (step is `mint_proxmox_token`-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)