### PR TITLE
Galaxy install from working_directory + tbot memory storage

### DIFF
--- a/.github/workflows/ansible-pr.yml
+++ b/.github/workflows/ansible-pr.yml
@@ -125,7 +125,10 @@ jobs:
           key: galaxy-${{ runner.os }}-${{ hashFiles(inputs.requirements_galaxy) }}
       - name: Install Galaxy collections/roles
         if: ${{ hashFiles(inputs.requirements_galaxy) != '' }}
-        run: ansible-galaxy collection install -r "${{ inputs.requirements_galaxy }}" || true
+        # From working_directory so ansible.cfg's roles_path/collections_path apply
+        # (matches the runner and the source repos' `cd ansible && ansible-galaxy install`).
+        working-directory: ${{ inputs.working_directory }}
+        run: ansible-galaxy install -r "${GITHUB_WORKSPACE}/${{ inputs.requirements_galaxy }}"
       - name: yamllint
         working-directory: ${{ inputs.working_directory }}
         run: yamllint ${{ inputs.lint_paths }}

--- a/.github/workflows/ansible-run.yml
+++ b/.github/workflows/ansible-run.yml
@@ -207,7 +207,12 @@ jobs:
 
       - name: Install Galaxy collections/roles
         if: ${{ hashFiles(inputs.requirements_galaxy) != '' }}
-        run: ansible-galaxy install -r "${{ inputs.requirements_galaxy }}" || true
+        # From working_directory so ansible.cfg's roles_path/collections_path apply —
+        # repos like vpn-maestra resolve roles from repo-relative paths, not ~/.ansible
+        # (source repos all ran `cd ansible && ansible-galaxy install`). No `|| true`:
+        # a galaxy failure must surface here, not later as "role not found".
+        working-directory: ${{ inputs.working_directory }}
+        run: ansible-galaxy install -r "${GITHUB_WORKSPACE}/${{ inputs.requirements_galaxy }}"
 
       - name: Get Teleport version from proxy
         id: tp-version
@@ -253,6 +258,10 @@ jobs:
             join_method: github
             token: ${{ inputs.teleport_join_token }}
           proxy_server: ${{ inputs.teleport_fqdn }}
+          # memory storage: default /var/lib/teleport is not writable on hosted
+          # runners (mkdir: permission denied -> tunnel never opens).
+          storage:
+            type: memory
           services:
             - type: application-tunnel
               app_name: ${{ inputs.teleport_app }}


### PR DESCRIPTION
Two live failures from the wave-2 consumer migrations:

1. **vpn-maestra ([#141](https://github.com/maestra-io/vpn-maestra/pull/141))**: `role 'ansible-netplan' was not found`. Source repos ran `cd ansible && ansible-galaxy install -r requirements.yml`, so `ansible.cfg`'s repo-relative `roles_path` applied; central ran galaxy from the workspace root → roles landed in `~/.ansible/roles`, not on the repo's roles_path. Fix: galaxy install runs from `working_directory` (runner + PR lint), `|| true` dropped so galaxy failures surface at install time, `ansible-galaxy install` (roles **and** collections, like the source repos) instead of collections-only in lint.
2. **mssql ([#27](https://github.com/maestra-io/mssql-maestra/pull/27)) / AD ([#84](https://github.com/maestra-io/active-directory-maestra/pull/84)) vault tunnel**: tbot defaulted storage to `/var/lib/teleport` → `mkdir: permission denied` on hosted runners → tunnel never opened → `ECONNREFUSED 127.0.0.1:8200`. The source repos' tbot config had `storage: type: memory`; restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated Ansible workflows to run `ansible-galaxy install` from each repo’s `working_directory`, using workspace-relative requirements paths and removing `|| true` so dependency install failures now fail the job immediately.

Also restored `tbot` vault tunnel config for hosted runners to use in-memory storage, avoiding permission errors from the default on-disk storage path.

Breaking changes: none expected, though workflow failures will now surface earlier instead of being suppressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->