### PR TITLE
terraform-pr: drop comment-job permissions block (startup_failure fix)

### DIFF
--- a/.github/workflows/terraform-pr.yml
+++ b/.github/workflows/terraform-pr.yml
@@ -143,9 +143,12 @@ jobs:
     needs: [fmt, plan]
     if: ${{ always() && github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      actions: read
+    # NO job-level permissions block here: a CALLED workflow may not request
+    # permissions the caller didn't grant (the source repos' standalone
+    # terraform-pr had `actions: read` here -> as a reusable this made GitHub
+    # reject the whole workflow with a blank startup_failure). Inherits the
+    # caller grant (contents:read, id-token:write, pull-requests:write) --
+    # same-run artifact download works without actions:read (phase-1 proven).
     steps:
       - name: Download all plan artifacts
         uses: actions/download-artifact@v8 # TODO: SHA-pin via Renovate on landing


### PR DESCRIPTION
A **called** workflow may not request permissions the caller didn't grant. The `comment` job carried `permissions: {pull-requests: write, actions: read}` — copied from the source repos' *standalone* `terraform-pr` workflows where that's legal — and `actions: read` exceeds the thin-callers' grant → GitHub rejected the entire reusable chain with a blank `startup_failure` on the pilot ([maestra-nat-gateway#168](https://github.com/maestra-io/maestra-nat-gateway/pull/168)).

Bisected empirically (`@tf-pr-bisect` branch): `terraform-run` validates **and ran a live omicron plan green end-to-end** (teleport auth → per-run pveum mint → WI state creds → tunnels → plan); the comment job's permissions block was the sole culprit. Fix = inherit the caller grant (the phase-1 ansible commenter runs identically without `actions: read`, prod-proven on 7 repos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)