### PR TITLE
fix(ansible-run): set GH_TOKEN in Execute step env (was empty via caller)

### DIFF
--- a/.github/workflows/ansible-run.yml
+++ b/.github/workflows/ansible-run.yml
@@ -339,6 +339,13 @@ jobs:
           VECTOR_SIEM_BASIC_AUTH_USER: ${{ secrets.VECTOR_SIEM_BASIC_AUTH_USER }}
           VECTOR_SIEM_BASIC_AUTH_PASSWORD: ${{ secrets.VECTOR_SIEM_BASIC_AUTH_PASSWORD }}
           PROXMOX_MONITORING_PASSWORD: ${{ secrets.PROXMOX_MONITORING_PASSWORD }}
+          # Token for `gh` CLI tasks (e.g. `gh release download` from a private
+          # repo). It MUST be set here in the reusable's own context, where
+          # github.token is populated. A caller cannot forward it: github.token
+          # (and secrets.*) resolve to EMPTY inside a reusable-workflow `with:`
+          # input, so forwarding it through `extra_env` shipped an empty value
+          # and `gh` ran unauthenticated (rc=4).
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -uo pipefail
 
@@ -346,6 +353,9 @@ jobs:
           if [ -n "${{ inputs.extra_env }}" ]; then
             while IFS= read -r line; do
               [ -z "$line" ] && continue
+              # skip a KEY= line with an empty value so it can't clobber a real
+              # step-env value (e.g. a caller forwarding an empty github.token)
+              case "$line" in *=) continue ;; esac
               export "$line"
             done <<< "${{ inputs.extra_env }}"
           fi


### PR DESCRIPTION
## Problem
`gh`-based ansible tasks authenticate via `GH_TOKEN`. Consumers forward it as `extra_env: GH_TOKEN=${{ github.token }}` in their `with:` block, but **`github.token` (and `secrets.*`) resolve to an empty string inside a reusable-workflow `with:` input**. So `GH_TOKEN` arrived empty, `gh` ran unauthenticated → `rc=4`, hidden by the task's `no_log`.

**Concrete breakage:** `maestra-io/haproxy-maestra` deploy — task *"Fetch haproxy-otel .deb on the controller"* (`gh release download … --repo maestra-io/haproxy-maestra`) fails on every haproxy host, blocking the omega apply. Verified in the failing run: the Execute step logged `extra_env: GH_TOKEN=` (genuinely empty, not masked `***`). Regressed in the "migrate ansible workflows to central reusables" change (moved token-passing from a job-level `env:` into a reusable `with:` input).

## Fix
- Set `GH_TOKEN: ${{ github.token }}` in the **Execute step's own `env:`** — evaluated in this reusable's context, where `github.token` is populated (callers use `secrets: inherit`).
- Harden the `extra_env` loop to **skip empty-value `KEY=` lines**, so a consumer still forwarding an empty `GH_TOKEN=` can't clobber the real value.

`ansible-run.yml` is byte-identical across v1.0.5→v1.1.1, so this is the only behavioral change since v1.0.5. Consumers should drop their `extra_env: GH_TOKEN=…` line and bump their pin to the tag cut from this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixes `ansible-run` authentication for `gh`-based Ansible tasks by setting `GH_TOKEN` directly in the `Execute Ansible` step environment with `${{ github.token }}`.

Also updates `extra_env` handling to ignore empty `KEY=` entries so a caller-provided empty value can’t override the real token.

Breaking change: callers should no longer pass `GH_TOKEN` via `extra_env`; the workflow now supplies it itself.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->