### PR TITLE
feat(terraform-run): add haproxy-cdp to rolling order + fail on unmatched keys

### DIFF
--- a/.github/workflows/terraform-run.yml
+++ b/.github/workflows/terraform-run.yml
@@ -658,15 +658,24 @@ jobs:
           fi
 
           # Order: privates first (internal traffic), then publics, then api
-          # (both external/customer-facing). Within each role, process numeric
-          # suffix in reverse so 02 goes before 01 — pairs with ansible's
-          # serial:1 convention. Every role must be listed here or its VMs are
-          # silently dropped from the rolling apply. (Ported verbatim from
-          # haproxy-maestra — rolling is haproxy-shaped by design.)
+          # and cdp (all external/customer-facing). Within each role, process
+          # numeric suffix in reverse so 02 goes before 01 — pairs with
+          # ansible's serial:1 convention. Every role must be listed here or
+          # its VMs are dropped from the rolling apply — the unmatched-key
+          # check below turns that former silent drop into a hard error.
+          # (Ported verbatim from haproxy-maestra — rolling is haproxy-shaped
+          # by design.)
           PRIVATE=$(echo "$CHANGED" | grep '^haproxy-private' | sort -r || true)
           PUBLIC=$(echo "$CHANGED" | grep '^haproxy-public' | sort -r || true)
           API=$(echo "$CHANGED" | grep '^haproxy-api' | sort -r || true)
-          ORDERED=$(echo -e "${PRIVATE}\n${PUBLIC}\n${API}" | sed '/^$/d')
+          CDP=$(echo "$CHANGED" | grep '^haproxy-cdp' | sort -r || true)
+          ORDERED=$(echo -e "${PRIVATE}\n${PUBLIC}\n${API}\n${CDP}" | sed '/^$/d')
+
+          UNMATCHED=$(comm -23 <(echo "$CHANGED" | sort) <(echo "$ORDERED" | sort) | sed '/^$/d')
+          if [ -n "$UNMATCHED" ]; then
+            echo "::error::Rolling apply has no ordering for these changed VM keys (add their role to the PRIVATE/PUBLIC/API/CDP lists): $UNMATCHED"
+            exit 1
+          fi
 
           TOTAL=$(echo "$ORDERED" | wc -l | tr -d ' ')
           COUNT=0


### PR DESCRIPTION
## Summary

maestra-io/haproxy-maestra#242 adds a new `haproxy-cdp` farm (2 VMs in omega + 2 in omicron). The rolling-apply ordering in `terraform-run.yml` only lists private/public/api, so cdp VM keys captured by the `module.haproxy` prefix would be **silently dropped** from a rolling apply (the caveat already documented in the comment).

- Adds `CDP` bucket after `API` (cdp is external/customer-facing, same tier as api).
- Turns the "unlisted role = silently dropped" behavior into a hard `::error` + exit 1 listing the unmatched keys, so the next new farm fails loud instead of no-oping.

Initial VM creation in #242 is unaffected either way (token/route53 additions force the non-rolling fallback), but subsequent cdp-only changes (resizes, external-IP attach) need this.

After merge: tag a release (v1.1.3) and haproxy-maestra bumps its pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)