### PR TITLE
fix(terraform-run): rolling apply targets full plan address (fixes multi-module farms)

### DIFF
--- a/.github/workflows/terraform-run.yml
+++ b/.github/workflows/terraform-run.yml
@@ -628,7 +628,8 @@ jobs:
           PREFIX='${{ inputs.rolling_module_prefix }}'
           PLAN_JSON=$(terraform show -json tfplan)
 
-          # Rolling apply targets <prefix>[X] one at a time. If the plan also
+          # Rolling apply targets each changed resource by its full plan
+          # address one at a time. If the plan also
           # touches anything outside the prefix (provider config drift, firewall
           # security groups, route53 records, etc.) rolling can't cover it, so
           # fall back to a normal parallel apply rather than refusing to deploy.
@@ -649,7 +650,6 @@ jobs:
              | select(.address | startswith($p))
              | select(.change.actions != ["no-op"])
              | .address
-             | capture("\\[\"(?<key>[^\"]+)\"\\]").key
             ] | unique | .[]')
 
           if [ -z "$CHANGED" ]; then
@@ -665,10 +665,10 @@ jobs:
           # check below turns that former silent drop into a hard error.
           # (Ported verbatim from haproxy-maestra — rolling is haproxy-shaped
           # by design.)
-          PRIVATE=$(echo "$CHANGED" | grep '^haproxy-private' | sort -r || true)
-          PUBLIC=$(echo "$CHANGED" | grep '^haproxy-public' | sort -r || true)
-          API=$(echo "$CHANGED" | grep '^haproxy-api' | sort -r || true)
-          CDP=$(echo "$CHANGED" | grep '^haproxy-cdp' | sort -r || true)
+          PRIVATE=$(echo "$CHANGED" | grep '\["haproxy-private' | sort -r || true)
+          PUBLIC=$(echo "$CHANGED" | grep '\["haproxy-public' | sort -r || true)
+          API=$(echo "$CHANGED" | grep '\["haproxy-api' | sort -r || true)
+          CDP=$(echo "$CHANGED" | grep '\["haproxy-cdp' | sort -r || true)
           ORDERED=$(echo -e "${PRIVATE}\n${PUBLIC}\n${API}\n${CDP}" | sed '/^$/d')
 
           UNMATCHED=$(comm -23 <(echo "$CHANGED" | sort) <(echo "$ORDERED" | sort) | sed '/^$/d')
@@ -685,7 +685,7 @@ jobs:
 
           for VM in $ORDERED; do
             COUNT=$((COUNT + 1))
-            TARGET="${PREFIX}[\"${VM}\"]"
+            TARGET="${VM}"
             echo "::group::[$COUNT/$TOTAL] Applying ${TARGET}"
             terraform apply -auto-approve -target="$TARGET"
             echo "::endgroup::"


### PR DESCRIPTION
## Problem
Rolling apply extracted only the for_each **key** from each changed resource and rebuilt the target as `${PREFIX}["key"]`, assuming every VM lives in a single module named exactly `${PREFIX}`.

`us-omicron` splits its HAProxy VMs across three modules sharing the `module.haproxy` prefix:

| module | source | farms |
|---|---|---|
| `module.haproxy` | haproxy-vm | public / private |
| `module.haproxy_api` | haproxy-vm-direct | api |
| `module.haproxy_cdp` | haproxy-vm-direct | cdp |

For `_api`/`_cdp`, the reconstructed target `module.haproxy["key"]` **doesn't exist** → `terraform apply -target=…` matched nothing → **0 resources applied (silent no-op)**.

This is exactly what bit re-creating `us-omicron-lw-haproxy-cdp-01`: `Rolling apply for 2 VM(s): haproxy-cdp-02 haproxy-cdp-01` → `Apply complete! Resources: 0 added` while the VM was never created. (api never hit it only because api farms were created via the non-rolling normal-apply fallback.)

## Fix
Carry the **full plan address** through `CHANGED`, bucket by the bracketed for_each key (module-name-agnostic), and `-target` the address as-is.

Verified by simulation over all three modules: ordering private→public→api→cdp (02 before 01) preserved, unmatched-key guard stays empty, targets now carry the correct module name (`module.haproxy_cdp["haproxy-cdp-01"]`).

Follows #18 (which added the cdp bucket). Refs [issues-maestra#1163](https://github.com/maestra-io/issues-maestra/issues/1163).

🤖 Generated with [Claude Code](https://claude.com/claude-code)