### PR TITLE
fix(terraform-run): add email-tracking + callback-receiver to rolling apply ordering

### DIFF
--- a/.github/workflows/terraform-run.yml
+++ b/.github/workflows/terraform-run.yml
@@ -657,19 +657,21 @@ jobs:
             exit 0
           fi
 
-          # Order: privates first (internal traffic), then publics, then api
-          # and cdp (all external/customer-facing). Within each role, process
-          # numeric suffix in reverse so 02 goes before 01 — pairs with
-          # ansible's serial:1 convention. Every role must be listed here or
-          # its VMs are dropped from the rolling apply — the unmatched-key
-          # check below turns that former silent drop into a hard error.
-          # (Ported verbatim from haproxy-maestra — rolling is haproxy-shaped
-          # by design.)
+          # Order: privates first (internal traffic), then publics, api, cdp,
+          # email-tracking and callback-receiver (all external/customer-facing).
+          # Within each role, process numeric suffix in reverse so 02 goes
+          # before 01 — pairs with ansible's serial:1 convention. Every role
+          # must be listed here or its VMs are dropped from the rolling apply —
+          # the unmatched-key check below turns that former silent drop into a
+          # hard error. (Ported verbatim from haproxy-maestra — rolling is
+          # haproxy-shaped by design.)
           PRIVATE=$(echo "$CHANGED" | grep '\["haproxy-private' | sort -r || true)
           PUBLIC=$(echo "$CHANGED" | grep '\["haproxy-public' | sort -r || true)
           API=$(echo "$CHANGED" | grep '\["haproxy-api' | sort -r || true)
           CDP=$(echo "$CHANGED" | grep '\["haproxy-cdp' | sort -r || true)
-          ORDERED=$(echo -e "${PRIVATE}\n${PUBLIC}\n${API}\n${CDP}" | sed '/^$/d')
+          EMAIL=$(echo "$CHANGED" | grep '\["haproxy-email' | sort -r || true)
+          CALLBACK=$(echo "$CHANGED" | grep '\["haproxy-callback' | sort -r || true)
+          ORDERED=$(echo -e "${PRIVATE}\n${PUBLIC}\n${API}\n${CDP}\n${EMAIL}\n${CALLBACK}" | sed '/^$/d')
 
           UNMATCHED=$(comm -23 <(echo "$CHANGED" | sort) <(echo "$ORDERED" | sort) | sed '/^$/d')
           if [ -n "$UNMATCHED" ]; then


### PR DESCRIPTION
The rolling-apply ordering step recognized only `haproxy-private/public/api/cdp`. A rolling `terraform apply` that changes a **`haproxy-email-tracking`** or **`haproxy-callback-receiver`** VM (both external/customer-facing farms, now live in haproxy-maestra omega + omicron) falls into the unmatched-key guard and hard-fails:

```
Rolling apply has no ordering for these changed VM keys (add their role to the PRIVATE/PUBLIC/API/CDP lists): module.haproxy_callback_receiver["haproxy-callback-receiver-01"]…
```

(Hit while standing up the omicron callback-receiver pair — the omicron terraform job runs `rolling: true`.)

**Fix:** add `EMAIL` + `CALLBACK` grep lists and append them to `ORDERED` after `cdp` (they're external-facing, same tier). No behaviour change for the existing four roles.

After merge I'll cut a new tag and re-pin haproxy-maestra's `terraform-run.yml` caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds `haproxy-email-tracking` (`EMAIL`) and `haproxy-callback-receiver` (`CALLBACK`) to rolling Terraform apply ordering.
- Sequences both roles after `haproxy-cdp`, preserving reverse numeric VM ordering within each role.
- Updates the inline ordering documentation and prevents unmatched-key failures for these VMs.

No breaking changes; existing role behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->