### PR TITLE
feat(ansible-run): configurable Teleport certificate TTL

### DIFF
--- a/.github/workflows/ansible-run.yml
+++ b/.github/workflows/ansible-run.yml
@@ -93,6 +93,16 @@ on:
         required: false
         type: string
         default: ""
+      certificate_ttl:
+        description: >-
+          Teleport SSH certificate TTL. Must exceed the LONGEST expected play
+          runtime: the cert is minted once at job start, and a run that
+          outlives it dies mid-play with 'ssh: cert has expired' on every
+          host at the same moment (bit mssql-maestra's fresh Windows installs
+          at exactly 1h). Capped by the bot role's max_session_ttl.
+        required: false
+        type: string
+        default: "1h"
       vault_role:
         description: "Vault JWT role name (auth method jwt-github)"
         required: false
@@ -238,7 +248,7 @@ jobs:
         with:
           proxy: ${{ inputs.teleport_fqdn }}
           token: ${{ inputs.teleport_join_token }}
-          certificate-ttl: 1h
+          certificate-ttl: ${{ inputs.certificate_ttl }}
 
       # --- Mitogen (Linux only) ------------------------------------------
       - name: Configure Mitogen strategy plugin


### PR DESCRIPTION
The reusable ansible-run mints the Teleport SSH cert once at job start with a hardcoded `certificate-ttl: 1h`. Any play that outlives it dies mid-run with `ssh: cert has expired` on every host simultaneously — bit mssql-maestra's first full fresh-install deploy at exactly 0:59:54 ([run](https://github.com/maestra-io/mssql-maestra/actions/runs/29325672032)).

Adds a `certificate_ttl` input, default **1h** (no change for existing consumers). Long-running consumers opt in per call — mssql-maestra will pass **2h** (fresh Windows installs run in parallel, so ~10 hosts ≈ the same wall-clock as 2, plus margin). Requested TTL is capped by the bot role's `max_session_ttl` — if the cap is lower, teleport-actions/auth fails loudly at job start rather than mid-play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMbTFX55LW2xfXpkSsNiJy