### PR TITLE
feat(ansible): shared rolling OS-update workflow + maestra.infra.os_update role

### DIFF
--- a/.github/workflows/ansible-os-update.yml
+++ b/.github/workflows/ansible-os-update.yml
@@ -1,0 +1,272 @@
+# maestra-io/github-actions/.github/workflows/ansible-os-update.yml
+#
+# Rolling OS update (apt + kernel + reboot) for the pet VMs — haproxy farms, NAT
+# gateways, VPN hosts. issues-maestra#1104.
+#
+# WHY A PER-HOST MATRIX AND NOT `serial: 1` INSIDE ONE ANSIBLE RUN
+# teleport-actions/auth mints ONE SSH certificate per job, at job start
+# (ansible-run.yml). A 12-host farm at ~14 min/host is ~2.5h — well past any
+# certificate TTL the bot role will grant, and the cert dies on every remaining
+# host at the same instant. haproxy-maestra already has this burn on record
+# (deploy.yml: "rolling_interval=180s stretches the apply past the Teleport SSH
+# session lifetime — run 25733140071 lost the API tunnel ~16 minutes in").
+# One job per host = a fresh cert per host, and "Re-run failed jobs" becomes the
+# resume button: it replays the failed host and everything fail-fast cancelled,
+# in order, reusing enumerate/plan.
+#
+# The per-host jobs deliberately keep the FARM-level concurrency group of
+# ansible-run.yml (they do not pass a concurrency_suffix), so an os-update can
+# never interleave with a normal config deploy of the same farm — a deploy landing
+# mid-drain would happily unmask keepalived/haproxy on a host we just drained.
+name: Ansible OS Update (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      playbook:
+        description: "Playbook path relative to working_directory."
+        required: false
+        type: string
+        default: "playbooks/os-update.yml"
+      inventory:
+        required: false
+        type: string
+        default: "inventory/teleport_inventory.py"
+      working_directory:
+        required: false
+        type: string
+        default: "ansible"
+      region:
+        required: true
+        type: string
+      environment:
+        required: true
+        type: string
+      site:
+        required: true
+        type: string
+      inventory_group_suffix:
+        description: "Suffix appended to <region>_<env>_<site> to form the target group (_nat_gateway, _vpn, _haproxy_public, ...)."
+        required: false
+        type: string
+        default: ""
+      host_limit:
+        description: "Single-host escape hatch. When set, the matrix is that one host."
+        required: false
+        type: string
+        default: ""
+      mode:
+        description: "plan | apply | undrain-only. `plan` mutates nothing."
+        required: false
+        type: string
+        default: "plan"
+      order:
+        description: >-
+          Explicit host order, CSV. Empty = alphabetical. Every name must exist in the
+          target group (a typo fails the run rather than silently skipping a host).
+        required: false
+        type: string
+        default: ""
+      alertmanager_app:
+        description: "Teleport app for the Alertmanager tunnel (maintenance silences)."
+        required: false
+        type: string
+        default: "alertmanager"
+      silence_minutes:
+        description: "Dead-man window for the silences. Must stay < OsUpdateHostStrandedDrain's for: (30m)."
+        required: false
+        type: number
+        default: 25
+      reboot_timeout:
+        required: false
+        type: number
+        default: 900
+      post_reboot_delay:
+        description: "Seconds to wait after reboot before probing — must cover Teleport agent re-registration."
+        required: false
+        type: number
+        default: 45
+      certificate_ttl:
+        description: "Per-HOST job, so 1h is ample. Capped by the bot role's max_session_ttl."
+        required: false
+        type: string
+        default: "1h"
+      max_hosts:
+        description: "Refuse to run if the group is bigger than this (typo/label-drift guard)."
+        required: false
+        type: number
+        default: 20
+      extra_run_args:
+        required: false
+        type: string
+        default: ""
+    secrets:
+      VECTOR_SIEM_BASIC_AUTH_USER:
+        required: false
+      VECTOR_SIEM_BASIC_AUTH_PASSWORD:
+        required: false
+      PROXMOX_MONITORING_PASSWORD:
+        required: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  enumerate:
+    runs-on: ubuntu-latest
+    outputs:
+      hosts: ${{ steps.list.outputs.hosts }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+
+      - name: Install ansible
+        run: uv pip install --system -r ansible/requirements-pip.txt
+
+      - name: Get Teleport version from proxy
+        id: tp-version
+        run: |
+          VER="$(/usr/bin/curl -sf "https://teleport.maestra.io:443/webapi/find" \
+            | jq -r '.auto_update.tools_version // .server_version')"
+          echo "version=${VER}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Teleport
+        uses: teleport-actions/setup@v1
+        with:
+          version: ${{ steps.tp-version.outputs.version }}
+
+      - name: Teleport auth
+        id: teleport-auth
+        uses: teleport-actions/auth@v2
+        with:
+          proxy: teleport.maestra.io:443
+          token: github-actions-infra-deploy
+          certificate-ttl: 30m
+
+      - name: Build the host list
+        id: list
+        working-directory: ${{ inputs.working_directory }}
+        env:
+          TELEPORT_IDENTITY_FILE: ${{ steps.teleport-auth.outputs.identity-file }}
+          TBOT_DEST_DIR: ${{ steps.teleport-auth.outputs.destination-dir }}
+          TELEPORT_PROXY: teleport.maestra.io:443
+          GROUP: ${{ inputs.region }}_${{ inputs.environment }}_${{ inputs.site }}${{ inputs.inventory_group_suffix }}
+          HOST_LIMIT: ${{ inputs.host_limit }}
+          ORDER: ${{ inputs.order }}
+          MAX_HOSTS: ${{ inputs.max_hosts }}
+        run: |
+          set -euo pipefail
+          ansible-inventory -i "${{ inputs.inventory }}" --list > /tmp/inv.json
+
+          if [ -n "${HOST_LIMIT}" ]; then
+            HOSTS="$(jq -cn --arg h "${HOST_LIMIT}" '[$h]')"
+          elif [ -n "${ORDER}" ]; then
+            # Explicit order. Every named host must be in the group — a typo must fail
+            # the run, not silently drop a host from the fleet sweep.
+            HOSTS="$(jq -c --arg g "${GROUP}" --arg o "${ORDER}" '
+              ($o | split(",") | map(gsub("^\\s+|\\s+$";""))) as $want
+              | (.[$g].hosts // []) as $have
+              | ($want - $have) as $bogus
+              | if ($bogus | length) > 0
+                then error("hosts not in group \($g): \($bogus | join(", "))")
+                else $want end' /tmp/inv.json)"
+          else
+            HOSTS="$(jq -c --arg g "${GROUP}" '(.[$g].hosts // []) | sort' /tmp/inv.json)"
+          fi
+
+          N="$(echo "${HOSTS}" | jq 'length')"
+          if [ "${N}" -eq 0 ]; then
+            echo "::error::No hosts matched group ${GROUP}"
+            exit 1
+          fi
+          if [ "${N}" -gt "${MAX_HOSTS}" ]; then
+            echo "::error::${N} hosts > max_hosts=${MAX_HOSTS} for group ${GROUP} — refusing (label drift?)"
+            exit 1
+          fi
+
+          echo "hosts=${HOSTS}" >> "$GITHUB_OUTPUT"
+          {
+            echo "### OS update — ${N} host(s) in \`${GROUP}\`, in this order"
+            echo ""
+            echo "${HOSTS}" | jq -r 'to_entries[] | "\(.key + 1). `\(.value)`"'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Read-only across the WHOLE group: pending packages, reboot decision, /boot
+  # headroom, peer health, and "is anyone already drained". Never gated — you
+  # approve `apply` after you have read the plan.
+  plan:
+    needs: enumerate
+    uses: ./.github/workflows/ansible-run.yml
+    secrets: inherit
+    with:
+      playbook: ${{ inputs.playbook }}
+      inventory: ${{ inputs.inventory }}
+      working_directory: ${{ inputs.working_directory }}
+      region: ${{ inputs.region }}
+      environment: ${{ inputs.environment }}
+      site: ${{ inputs.site }}
+      inventory_group_suffix: ${{ inputs.inventory_group_suffix }}
+      host_limit: ${{ inputs.host_limit }}
+      # NOT --check: command/shell/apt are skipped in check mode, which would leave
+      # every probe register undefined and make the plan a green no-op.
+      check_mode: false
+      use_mitogen: false
+      no_hosts_fail_on_apply: true
+      certificate_ttl: 30m
+      tbot_tunnels: |
+        app=${{ inputs.alertmanager_app }} listen=9093
+      extra_run_args: >-
+        -e os_update_mode=plan
+        -e os_update_am_url=http://127.0.0.1:9093
+        ${{ inputs.extra_run_args }}
+      artifact_name: os-update-plan-${{ inputs.region }}-${{ inputs.environment }}-${{ inputs.site }}${{ inputs.inventory_group_suffix }}-${{ github.run_number }}
+
+  apply:
+    needs: [enumerate, plan]
+    if: ${{ inputs.mode == 'apply' || inputs.mode == 'undrain-only' }}
+    strategy:
+      matrix:
+        host: ${{ fromJSON(needs.enumerate.outputs.hosts) }}
+      max-parallel: 1
+      fail-fast: true
+    uses: ./.github/workflows/ansible-run.yml
+    secrets: inherit
+    with:
+      playbook: ${{ inputs.playbook }}
+      inventory: ${{ inputs.inventory }}
+      working_directory: ${{ inputs.working_directory }}
+      region: ${{ inputs.region }}
+      environment: ${{ inputs.environment }}
+      site: ${{ inputs.site }}
+      inventory_group_suffix: ${{ inputs.inventory_group_suffix }}
+      host_limit: ${{ matrix.host }}
+      check_mode: false
+      use_mitogen: false
+      no_hosts_fail_on_apply: true
+      certificate_ttl: ${{ inputs.certificate_ttl }}
+      tbot_tunnels: |
+        app=${{ inputs.alertmanager_app }} listen=9093
+      extra_run_args: >-
+        -e os_update_mode=${{ inputs.mode }}
+        -e os_update_am_url=http://127.0.0.1:9093
+        -e os_update_silence_minutes=${{ inputs.silence_minutes }}
+        -e os_update_reboot_timeout=${{ inputs.reboot_timeout }}
+        -e os_update_post_reboot_delay=${{ inputs.post_reboot_delay }}
+        -e os_update_run_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        ${{ inputs.extra_run_args }}
+      artifact_name: os-update-${{ matrix.host }}-${{ github.run_number }}
+      # The family rule (ansible-manual.yml): omega is gated by a GitHub Environment,
+      # omicron is not. Never invent an environment name for omicron — GitHub would
+      # silently create it WITHOUT protection rules, which reads like a gate and isn't one.
+      gh_environment: ${{ inputs.environment == 'omega' && format('{0}-{1}-{2}', inputs.region, inputs.environment, inputs.site) || '' }}

--- a/.github/workflows/ansible-run.yml
+++ b/.github/workflows/ansible-run.yml
@@ -93,6 +93,17 @@ on:
         required: false
         type: string
         default: ""
+      tbot_tunnels:
+        description: >-
+          Generic Teleport app tunnels for the play, one `app=<teleport-app> listen=<port>`
+          per line. Starts a single tbot with N application-tunnel services and exports
+          TUNNEL_<APP_UPPER_SNAKE>=http://127.0.0.1:<port> into the Execute env.
+          Fails the job if a tunnel never opens — a play that silently loses its
+          Alertmanager tunnel would drain and reboot a load balancer with no silences up.
+          Independent of vault_mode (which keeps its own dedicated :8200 tunnel).
+        required: false
+        type: string
+        default: ""
       certificate_ttl:
         description: >-
           Teleport SSH certificate TTL. Must exceed the LONGEST expected play
@@ -284,6 +295,64 @@ jobs:
             sleep 1
           done
 
+      # --- Generic Teleport app tunnels (os-update: Alertmanager) --------
+      - name: Start Teleport app tunnels
+        id: app-tunnels
+        if: ${{ inputs.tbot_tunnels != '' }}
+        env:
+          TBOT_TUNNELS: ${{ inputs.tbot_tunnels }}
+        run: |
+          set -euo pipefail
+          {
+            echo "version: v2"
+            echo "proxy_server: ${{ inputs.teleport_fqdn }}"
+            echo "onboarding:"
+            echo "  join_method: github"
+            echo "  token: ${{ inputs.teleport_join_token }}"
+            # memory storage: /var/lib/teleport is not writable on hosted runners.
+            echo "storage:"
+            echo "  type: memory"
+            echo "services:"
+          } > /tmp/tbot-apps.yaml
+
+          PAIRS=""
+          while IFS= read -r line; do
+            [ -z "${line// /}" ] && continue
+            app="$(printf '%s' "$line" | sed -n 's/.*app=\([^ ]*\).*/\1/p')"
+            port="$(printf '%s' "$line" | sed -n 's/.*listen=\([0-9]*\).*/\1/p')"
+            if [ -z "$app" ] || [ -z "$port" ]; then
+              echo "::error::malformed tbot_tunnels line (want 'app=<name> listen=<port>'): $line"
+              exit 1
+            fi
+            {
+              echo "  - type: application-tunnel"
+              echo "    app_name: ${app}"
+              echo "    listen: tcp://127.0.0.1:${port}"
+            } >> /tmp/tbot-apps.yaml
+            PAIRS="${PAIRS} ${app}:${port}"
+          done <<< "${TBOT_TUNNELS}"
+
+          tbot start -c /tmp/tbot-apps.yaml &
+          echo "pid=$!" >> "$GITHUB_OUTPUT"
+
+          for pair in ${PAIRS}; do
+            app="${pair%%:*}"; port="${pair##*:}"
+            opened=0
+            for _ in $(seq 1 30); do
+              if (exec 3<>/dev/tcp/127.0.0.1/"${port}") 2>/dev/null; then opened=1; break; fi
+              sleep 1
+            done
+            # FAIL CLOSED. No tunnel -> no silences -> we would page Rootly for every
+            # host we reboot, and the "is anyone else drained" interlock would be blind.
+            if [ "${opened}" != 1 ]; then
+              echo "::error::tbot tunnel for app '${app}' never opened on 127.0.0.1:${port}"
+              exit 1
+            fi
+            slug="$(printf '%s' "${app}" | tr 'a-z-' 'A-Z_')"
+            echo "TUNNEL_${slug}=http://127.0.0.1:${port}" >> "$GITHUB_ENV"
+            echo "tunnel for ${app} is up on 127.0.0.1:${port}"
+          done
+
       # --- Vault: fetch secrets (public OR tunnel) -----------------------
       - name: Retrieve secrets from Vault
         if: ${{ inputs.vault_mode != 'none' && inputs.vault_secrets != '' }}
@@ -415,6 +484,10 @@ jobs:
       - name: Stop Vault tunnel
         if: ${{ always() && inputs.vault_mode == 'tunnel' && steps.vault-tunnel.outputs.tunnel_pid != '' }}
         run: kill "${{ steps.vault-tunnel.outputs.tunnel_pid }}" || true
+
+      - name: Stop Teleport app tunnels
+        if: ${{ always() && steps.app-tunnels.outputs.pid != '' }}
+        run: kill "${{ steps.app-tunnels.outputs.pid }}" || true
 
       # --- Proxmox token cleanup -----------------------------------------
       - name: Cleanup Proxmox API token

--- a/ansible/collections/maestra/infra/galaxy.yml
+++ b/ansible/collections/maestra/infra/galaxy.yml
@@ -1,0 +1,21 @@
+---
+namespace: maestra
+name: infra
+version: 1.0.0
+readme: README.md
+authors:
+  - Maestra Infrastructure
+description: >-
+  Shared Ansible content for Maestra infrastructure repos. Holds the os_update
+  role: the generic half of the fleet OS-update workflow (plan, apt, reboot,
+  Alertmanager silences, drain marker). The role-specific half (preflight /
+  drain / verify / undrain) is implemented by each consumer repo as a task-file
+  contract — see docs/ansible-os-update.md.
+license_expression: MIT
+tags:
+  - infrastructure
+  - patching
+repository: https://github.com/maestra-io/github-actions
+documentation: https://github.com/maestra-io/github-actions/blob/main/docs/ansible-os-update.md
+build_ignore:
+  - '*.tar.gz'

--- a/ansible/collections/maestra/infra/roles/os_update/defaults/main.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/defaults/main.yml
@@ -1,0 +1,57 @@
+---
+# maestra.infra.os_update — generic half of the fleet OS-update workflow.
+# The role-specific half lives in each consumer repo under
+# ansible/tasks/os-update/{vars,preflight,drain,verify,undrain,settle}.yml
+# (contract: docs/ansible-os-update.md).
+
+# plan | apply | undrain-only
+os_update_mode: plan
+
+# Where the consumer repo's hook task-files live (playbook_dir = <repo>/ansible/playbooks).
+os_update_hooks_dir: "{{ playbook_dir }}/../tasks/os-update"
+
+# Alertmanager, reached through the tbot app-tunnel started by ansible-run.yml
+# (tbot_tunnels: app=alertmanager listen=9093). Empty = refuse to apply.
+os_update_am_url: ""
+
+# Dead-man window for the maintenance silences. MUST stay below the `for:` of
+# the OsUpdateHostStrandedDrain alert, or the safety net silences itself.
+os_update_silence_minutes: 25
+
+# Reboot behaviour. post_reboot_delay covers Teleport agent re-registration:
+# the host is SSH-reachable only once its teleport agent is back in the proxy's
+# inventory, and ansible reconnects through the tsh ProxyCommand.
+os_update_reboot_timeout: 900
+os_update_post_reboot_delay: 45
+os_update_connect_timeout: 30
+
+# Packages that are owned by IaC (custom builds, pinned versions, or the very
+# transport we are riding on) and must NEVER be touched by the OS upgrade.
+# `teleport` is on this list because its postinst restarts the agent we are
+# connected through. Consumers add their own via os_update_pinned_extra.
+os_update_pinned_base:
+  - teleport
+  - frr
+  - frr-pythontools
+  - consul
+os_update_pinned_extra: []
+
+# Kernel GC only when /boot is genuinely tight — autoremove --purge has a wider
+# blast radius than "delete old kernels", so we don't run it speculatively.
+os_update_boot_free_gc_threshold_mb: 500
+os_update_boot_free_min_mb: 400
+
+# Drain marker: survives a runner crash, so a re-run can tell "this host was
+# left drained by a previous run" from "this host is healthy and in rotation".
+os_update_marker_dir: /var/lib/os-update
+os_update_marker_file: /var/lib/os-update/drained.json
+node_exporter_textfile_dir: /var/lib/node_exporter
+
+# Run URL, injected by the reusable workflow for the silence comment + marker.
+os_update_run_url: manual
+
+# Escape hatch for a deliberate fleet-wide local run (the playbook is normally
+# driven one host per GH job, so >1 host in the play means someone bypassed the
+# GH-level fail-fast / approval / artifact trail).
+os_update_allow_multi: false
+os_update_allow_single_node: false

--- a/ansible/collections/maestra/infra/roles/os_update/tasks/apt.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/apt.yml
@@ -1,0 +1,45 @@
+---
+# The payload. Runs only while the host is DRAINED.
+
+- name: Serialize against unattended-upgrades / apt-daily
+  # The apt-daily timers are masked on these boxes (harden-apt), but the
+  # unattended-upgrades unit itself is enabled and can still fire on boot.
+  # lock_timeout makes us wait for the dpkg lock instead of dying on it.
+  ansible.builtin.apt:
+    upgrade: dist
+    update_cache: true
+    lock_timeout: 300
+    autoremove: false
+    dpkg_options: force-confdef,force-confold
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+    # needrestart is not installed on these hosts, but if it ever lands, `a` keeps
+    # it from opening an interactive service-restart prompt and hanging the run.
+    NEEDRESTART_MODE: a
+  register: os_update_apt_result
+
+- name: Re-check whether the upgrade asked for a reboot
+  ansible.builtin.stat:
+    path: /var/run/reboot-required
+  register: os_update_reboot_flag_post
+  check_mode: false
+
+- name: Which packages asked for it
+  ansible.builtin.slurp:
+    src: /var/run/reboot-required.pkgs
+  register: os_update_reboot_pkgs
+  failed_when: false
+  check_mode: false
+
+- name: Recompute the reboot decision from the post-upgrade state
+  ansible.builtin.set_fact:
+    os_update_reboot_needed: >-
+      {{ os_update_reboot_needed
+         or os_update_reboot_flag_post.stat.exists }}
+
+- name: What the upgrade did
+  ansible.builtin.debug:
+    msg: >-
+      {{ inventory_hostname }}: apt changed={{ os_update_apt_result.changed }},
+      reboot_required={{ os_update_reboot_flag_post.stat.exists }},
+      reboot_pkgs={{ (os_update_reboot_pkgs.content | default('') | b64decode).split() | default([]) }}

--- a/ansible/collections/maestra/infra/roles/os_update/tasks/boot_safety.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/boot_safety.yml
@@ -1,0 +1,27 @@
+---
+# A headless VM that fails to boot once must not sit in the GRUB menu forever.
+#
+# Ubuntu writes `recordfail=1` on an unclean shutdown / failed boot, and GRUB then
+# IGNORES GRUB_TIMEOUT and waits for a keypress unless GRUB_RECORDFAIL_TIMEOUT is
+# set. Live on us-omicron-lw-haproxy-public-01: GRUB_TIMEOUT=0,
+# GRUB_TIMEOUT_STYLE=hidden, and no GRUB_RECORDFAIL_TIMEOUT at all — i.e. today the
+# first bad kernel turns "one host down, its peer carries the traffic" into "one
+# host down until a human opens the Proxmox console".
+#
+# This is the difference between a recoverable failed reboot and a manual rescue,
+# so it is a hard prerequisite of the reboot, not a nice-to-have.
+
+- name: GRUB must time out even after a recorded boot failure
+  ansible.builtin.lineinfile:
+    path: /etc/default/grub
+    regexp: '^#?\s*GRUB_RECORDFAIL_TIMEOUT='
+    line: "GRUB_RECORDFAIL_TIMEOUT={{ os_update_grub_recordfail_timeout | default(5) }}"
+    state: present
+    validate: /bin/true
+  register: os_update_grub
+
+- name: Regenerate grub.cfg
+  ansible.builtin.command:
+    argv: [update-grub]
+  when: os_update_grub.changed
+  changed_when: true

--- a/ansible/collections/maestra/infra/roles/os_update/tasks/guards.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/guards.yml
@@ -1,0 +1,56 @@
+---
+# "Is any OTHER host in this contour currently drained?"
+#
+# The source of truth is the Alertmanager silence, NOT a metric written by the
+# host being drained: a node_exporter textfile metric disappears exactly during
+# the reboot, so `count(os_update_drained{...}) == 0` evaluates over an EMPTY
+# vector — neither true nor false — and fails OPEN in the one window the guard
+# exists for. The silence lives off-box and carries an endsAt (dead-man).
+
+- name: Guard — an Alertmanager tunnel is mandatory before we drain anything
+  ansible.builtin.assert:
+    that: (os_update_am_url | default('')) | length > 0
+    fail_msg: >-
+      No Alertmanager URL. Refusing to drain/reboot without maintenance silences —
+      a rebooting LB/gateway pages Rootly within 1-3 minutes. The reusable workflow
+      opens the tunnel with `tbot_tunnels: app=alertmanager listen=9093`.
+  when: os_update_mode in ['apply', 'undrain-only']
+
+- name: Fetch the active silences
+  ansible.builtin.uri:
+    url: "{{ os_update_am_url }}/api/v2/silences"
+    return_content: true
+    status_code: 200
+  delegate_to: localhost
+  become: false
+  check_mode: false
+  register: os_update_silences
+  when: (os_update_am_url | default('')) | length > 0
+
+- name: Which other hosts hold an open os-update drain window
+  ansible.builtin.set_fact:
+    os_update_other_drains: >-
+      {{ os_update_silences.json
+         | default([])
+         | selectattr('status.state', 'equalto', 'active')
+         | selectattr('createdBy', 'defined')
+         | selectattr('createdBy', 'search', '^gha-os-update')
+         | rejectattr('comment', 'search', 'host=' ~ inventory_hostname ~ '(\\s|$)')
+         | map(attribute='comment')
+         | list }}
+  when: (os_update_am_url | default('')) | length > 0
+
+- name: Guard — exactly one host at a time, contour-wide
+  ansible.builtin.assert:
+    that: (os_update_other_drains | default([]) | length) == 0
+    fail_msg: >-
+      Another os-update drain window is open: {{ os_update_other_drains | default([]) }}.
+      Two hosts out of rotation at once is how a redundant pair becomes an outage. STOP.
+  when: os_update_mode == 'apply'
+
+- name: Guard — this host must have a peer (draining a singleton IS the outage)
+  ansible.builtin.assert:
+    that: (os_update_peers | length) > 0 or (os_update_allow_single_node | bool)
+    fail_msg: >-
+      {{ inventory_hostname }} has no peer in {{ os_update_farm }}. Draining it takes
+      the service down. Pass -e os_update_allow_single_node=true if that is genuinely intended.

--- a/ansible/collections/maestra/infra/roles/os_update/tasks/holds.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/holds.yml
@@ -1,0 +1,75 @@
+---
+# dpkg holds are the mechanism that keeps the OS upgrade off the IaC-owned
+# packages (custom haproxy/haproxy-otel builds, pinned frr, consul, and the
+# teleport agent we are literally connected through).
+#
+# Two things this deliberately does NOT do:
+#   * it does not try to scope apt to the Ubuntu archive via Dir::Etc::SourceList.
+#     On 24.04 the repos are deb822 .sources under sources.list.d (SourceParts) —
+#     overriding SourceList alone silently leaves every third-party repo enabled,
+#     i.e. a protection that reads correct and does nothing.
+#   * it does not trust the hold to be enough on its own: apt is free to satisfy a
+#     dependency by REMOVING a held package. The tripwire below catches that.
+
+- name: Apply holds
+  when: os_update_holds_action == 'apply'
+  block:
+    - name: Gather installed packages
+      ansible.builtin.package_facts:
+        manager: apt
+      check_mode: false
+
+    - name: Which pinned packages are actually installed here and not already held
+      ansible.builtin.set_fact:
+        os_update_our_holds: >-
+          {{ (os_update_pinned_base + os_update_pinned_extra)
+             | unique
+             | select('in', ansible_facts.packages)
+             | difference(os_update_holds_before)
+             | list }}
+
+    - name: Hold them
+      ansible.builtin.command:
+        argv: "{{ ['apt-mark', 'hold'] + os_update_our_holds }}"
+      register: os_update_hold_cmd
+      changed_when: "'set on hold' in os_update_hold_cmd.stdout"
+      check_mode: false
+      when: os_update_our_holds | length > 0
+
+    - name: Re-simulate with the holds in place
+      ansible.builtin.command:
+        argv: [apt-get, -s, dist-upgrade]
+      environment:
+        DEBIAN_FRONTEND: noninteractive
+      register: os_update_sim_held
+      changed_when: false
+      check_mode: false
+
+    - name: TRIPWIRE — no IaC-owned package may be installed, upgraded OR REMOVED
+      # `Remv haproxy-otel` is the catastrophic case: its postrm un-diverts
+      # /usr/sbin/haproxy and the load balancer never comes back after the reboot.
+      # Matching only `^Inst` would miss it entirely.
+      ansible.builtin.assert:
+        that:
+          - >-
+            os_update_sim_held.stdout_lines
+            | select('match', '^(Inst|Remv|Purg) (' ~ ((os_update_pinned_base + os_update_pinned_extra) | unique | join('|')) ~ ')( |$)')
+            | list | length == 0
+        fail_msg: >-
+          apt wants to touch a pinned package despite the holds:
+          {{ os_update_sim_held.stdout_lines
+             | select('match', '^(Inst|Remv|Purg) (' ~ ((os_update_pinned_base + os_update_pinned_extra) | unique | join('|')) ~ ')( |$)')
+             | list }}
+          Refusing to upgrade. Investigate the dependency that forces this.
+
+- name: Restore the pre-existing hold set
+  when: os_update_holds_action == 'restore'
+  block:
+    - name: Unhold only what WE held (someone else's pins stay put)
+      ansible.builtin.command:
+        argv: "{{ ['apt-mark', 'unhold'] + os_update_our_holds }}"
+      register: os_update_unhold_cmd
+      changed_when: "'canceled' in os_update_unhold_cmd.stdout"
+      check_mode: false
+      failed_when: false
+      when: (os_update_our_holds | default([]) | length) > 0

--- a/ansible/collections/maestra/infra/roles/os_update/tasks/kernel_gc.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/kernel_gc.yml
@@ -1,0 +1,30 @@
+---
+# Old kernels are only garbage-collected when /boot is genuinely tight, and only
+# AFTER a successful reboot — never before. `autoremove --purge` has a wider blast
+# radius than "delete old kernels", and the kernel we might have to fall back to is
+# worth more than the megabytes it occupies.
+
+- name: Re-measure /boot after the upgrade
+  ansible.builtin.shell:
+    executable: /bin/bash
+    cmd: |
+      set -o pipefail
+      df -Pm /boot | awk 'NR==2 {print $4}'
+  register: os_update_boot_free_post
+  changed_when: false
+  check_mode: false
+
+- name: Purge superseded kernels
+  ansible.builtin.apt:
+    autoremove: true
+    purge: true
+  register: os_update_gc
+  when:
+    - os_update_rebooted | default(false)
+    - (os_update_boot_free_post.stdout | trim | int) < (os_update_boot_free_gc_threshold_mb | int)
+
+- name: /boot after GC
+  ansible.builtin.debug:
+    msg: >-
+      {{ inventory_hostname }}: /boot free {{ os_update_boot_free_post.stdout | trim }} MB
+      {{ '(GC ran)' if (os_update_gc.changed | default(false)) else '(GC not needed)' }}

--- a/ansible/collections/maestra/infra/roles/os_update/tasks/main.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/main.yml
@@ -1,0 +1,147 @@
+---
+# Driver. One host per run (the reusable workflow fans out a per-host matrix);
+# `serial: 1` in the consumer playbook is only a safety net for a local operator.
+#
+# Order is load-bearing:
+#   vars -> guards -> marker(read) -> plan -> PREFLIGHT -> [silence -> drain ->
+#   boot_safety -> holds -> apt -> reboot -> kernel_gc -> VERIFY]
+#   always: holds(restore) -> UNDRAIN -> marker(clear) -> SETTLE -> unsilence
+#
+# PREFLIGHT sits immediately before the drain, in the same block — not in an
+# earlier play. Ansible finishes an entire play (all serial batches) before
+# starting the next one, so a preflight in play 1 would evaluate "is my peer
+# healthy?" long before the drain in play 2 ever touches the host.
+
+- name: Load the consumer repo's per-role vars (peers, expectations, silence sets)
+  ansible.builtin.include_tasks: "{{ os_update_hooks_dir }}/vars.yml"
+
+- name: Guard — nobody else in this contour is currently drained
+  ansible.builtin.include_tasks: guards.yml
+
+# ── escape hatch ───────────────────────────────────────────────────────────
+# Deliberately skips preflight: the peer gates there are exactly what fails in
+# the scenario this hatch exists for (a run died mid-drain and the pair is
+# already degraded).
+- name: UNDRAIN-ONLY (escape hatch)
+  when: os_update_mode == 'undrain-only'
+  block:
+    - name: Put the host back into rotation
+      ansible.builtin.include_tasks: "{{ os_update_hooks_dir }}/undrain.yml"
+
+    - name: Clear the drain marker
+      ansible.builtin.include_tasks: marker.yml
+      vars:
+        os_update_marker_action: clear
+
+    - name: Prove it is actually serving again
+      ansible.builtin.include_tasks: "{{ os_update_hooks_dir }}/settle.yml"
+
+    - name: Drop any silence this host still owns
+      ansible.builtin.include_tasks: unsilence.yml
+
+    - name: End of play for this host
+      ansible.builtin.meta: end_host
+
+- name: Read the drain marker (was this host left drained by an earlier run?)
+  ansible.builtin.include_tasks: marker.yml
+  vars:
+    os_update_marker_action: read
+
+- name: Plan — what would this update do (read-only, every probe check_mode:false)
+  ansible.builtin.include_tasks: plan.yml
+
+- name: PREFLIGHT — is the peer healthy, and is this host safe to reboot
+  ansible.builtin.include_tasks: "{{ os_update_hooks_dir }}/preflight.yml"
+
+- name: Plan report
+  ansible.builtin.debug:
+    msg: >-
+      {{ inventory_hostname }}
+      kernel={{ ansible_facts.kernel }} newest={{ os_update_newest_kernel }}
+      pending_pkgs={{ os_update_pending | length }}
+      needs_upgrade={{ os_update_needed }}
+      needs_reboot={{ os_update_reboot_needed }}
+      boot_free_mb={{ os_update_boot_free_mb }}
+      resuming_drain={{ os_update_resuming }}
+      pre_existing_holds={{ os_update_holds_before }}
+
+- name: Nothing to do — host is current, it is NOT drained and NOT rebooted
+  ansible.builtin.debug:
+    msg: "{{ inventory_hostname }}: already up to date, no reboot pending — untouched."
+  when:
+    - os_update_mode == 'apply'
+    - not (os_update_needed or os_update_reboot_needed or os_update_resuming)
+
+- name: APPLY
+  when:
+    - os_update_mode == 'apply'
+    - os_update_needed or os_update_reboot_needed or os_update_resuming
+  block:
+    # Silences go up BEFORE the drain, not before the reboot: HaproxySystemdUnitFailed
+    # (for: 1m) and the BGP/VRRP alerts fire on the drain itself.
+    - name: Silence this host's alerts (dead-man window)
+      ansible.builtin.include_tasks: silence.yml
+
+    - name: DRAIN — take the host out of rotation, persistently, and prove it
+      ansible.builtin.include_tasks: "{{ os_update_hooks_dir }}/drain.yml"
+
+    - name: Make the box safe to reboot headless
+      ansible.builtin.include_tasks: boot_safety.yml
+
+    - name: Pin the IaC-owned packages
+      ansible.builtin.include_tasks: holds.yml
+      vars:
+        os_update_holds_action: apply
+
+    - name: Upgrade
+      ansible.builtin.include_tasks: apt.yml
+      when: os_update_needed
+
+    - name: Reboot
+      ansible.builtin.include_tasks: reboot.yml
+      when: os_update_reboot_needed
+
+    - name: Reclaim /boot if it is tight
+      ansible.builtin.include_tasks: kernel_gc.yml
+
+    - name: VERIFY — the host is healthy again (still out of rotation)
+      ansible.builtin.include_tasks: "{{ os_update_hooks_dir }}/verify.yml"
+
+  rescue:
+    - name: Record the failure (we still un-drain in always)
+      ansible.builtin.set_fact:
+        os_update_failed: true
+
+    - name: Announce
+      ansible.builtin.debug:
+        msg: >-
+          FAILED on {{ inventory_hostname }} — un-draining this host, then aborting
+          the fleet (the GH matrix is fail-fast, no further host is touched).
+
+  always:
+    - name: Restore the pre-existing hold set
+      ansible.builtin.include_tasks: holds.yml
+      vars:
+        os_update_holds_action: restore
+
+    - name: UNDRAIN — put the host back into rotation (idempotent)
+      ansible.builtin.include_tasks: "{{ os_update_hooks_dir }}/undrain.yml"
+
+    - name: Clear the drain marker
+      ansible.builtin.include_tasks: marker.yml
+      vars:
+        os_update_marker_action: clear
+
+    - name: SETTLE — traffic is actually flowing again and the pair is redundant
+      ansible.builtin.include_tasks: "{{ os_update_hooks_dir }}/settle.yml"
+      when: not (os_update_failed | default(false))
+
+    - name: Drop the silences
+      ansible.builtin.include_tasks: unsilence.yml
+
+    - name: Fail the job (after the host was returned to rotation)
+      ansible.builtin.fail:
+        msg: >-
+          OS update FAILED on {{ inventory_hostname }}. The host was un-drained
+          (or the undrain itself failed — read above). No further host is touched.
+      when: os_update_failed | default(false)

--- a/ansible/collections/maestra/infra/roles/os_update/tasks/marker.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/marker.yml
@@ -1,0 +1,80 @@
+---
+# On-disk drain marker + a node_exporter textfile metric.
+#
+# The marker is NOT the interlock (that's the Alertmanager silence — see guards.yml).
+# It answers a different question, on the host itself: "did a previous run die
+# after draining me?" A runner that is cancelled or times out never executes
+# `always`, so the host can be left masked/stopped with nothing in-band to say so.
+#
+# The metric feeds OsUpdateHostStrandedDrain, whose expr uses last_over_time() so
+# it survives the reboot window (the series is gone while the box is down).
+
+- name: Read the marker
+  when: os_update_marker_action == 'read'
+  block:
+    - name: Slurp
+      ansible.builtin.slurp:
+        src: "{{ os_update_marker_file }}"
+      register: os_update_marker_raw
+      failed_when: false
+      check_mode: false
+
+    - name: Interpret
+      ansible.builtin.set_fact:
+        os_update_resuming: "{{ os_update_marker_raw.content is defined }}"
+        os_update_marker: >-
+          {{ (os_update_marker_raw.content | b64decode | from_json)
+             if (os_update_marker_raw.content is defined) else {} }}
+
+    - name: Announce a resumed drain
+      ansible.builtin.debug:
+        msg: >-
+          {{ inventory_hostname }} is ALREADY DRAINED by run
+          {{ os_update_marker.run | default('?') }} at {{ os_update_marker.started | default('?') }}.
+          Re-draining idempotently and finishing the job.
+      when: os_update_resuming
+
+- name: Write the marker
+  when: os_update_marker_action == 'write'
+  block:
+    - name: Marker dir
+      ansible.builtin.file:
+        path: "{{ os_update_marker_dir }}"
+        state: directory
+        mode: "0755"
+
+    - name: Marker file
+      ansible.builtin.copy:
+        dest: "{{ os_update_marker_file }}"
+        mode: "0644"
+        content: |
+          {{ {'host': inventory_hostname,
+              'farm': os_update_farm,
+              'run': os_update_run_url,
+              'started': ansible_facts.date_time.iso8601} | to_nice_json }}
+
+    - name: Textfile metric (feeds OsUpdateHostStrandedDrain)
+      ansible.builtin.copy:
+        dest: "{{ node_exporter_textfile_dir }}/os_update.prom"
+        mode: "0644"
+        content: |
+          # HELP os_update_drained 1 while an os-update run holds this host out of rotation.
+          # TYPE os_update_drained gauge
+          os_update_drained{run="{{ os_update_run_url }}"} 1
+
+- name: Clear the marker
+  when: os_update_marker_action == 'clear'
+  block:
+    - name: Remove the marker file
+      ansible.builtin.file:
+        path: "{{ os_update_marker_file }}"
+        state: absent
+
+    - name: Zero the metric (deleting the file would leave the last scrape stale)
+      ansible.builtin.copy:
+        dest: "{{ node_exporter_textfile_dir }}/os_update.prom"
+        mode: "0644"
+        content: |
+          # HELP os_update_drained 1 while an os-update run holds this host out of rotation.
+          # TYPE os_update_drained gauge
+          os_update_drained{run=""} 0

--- a/ansible/collections/maestra/infra/roles/os_update/tasks/plan.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/plan.yml
@@ -1,0 +1,92 @@
+---
+# Read-only. EVERY probe carries check_mode:false on purpose — command/shell/apt
+# are SKIPPED under --check, which leaves their registers undefined and turns any
+# assert built on them into either a crash or (worse, with `| default`) a silent
+# pass. The dry run of this workflow is `os_update_mode=plan`, not `--check`.
+
+- name: Refresh the package index
+  ansible.builtin.apt:
+    update_cache: true
+    cache_valid_time: 0
+    lock_timeout: 300
+  check_mode: false
+  changed_when: false
+
+- name: Simulate the upgrade
+  ansible.builtin.command:
+    argv: [apt-get, -s, dist-upgrade]
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+  register: os_update_sim
+  changed_when: false
+  check_mode: false
+
+- name: Packages the upgrade would install/upgrade
+  ansible.builtin.set_fact:
+    os_update_pending: "{{ os_update_sim.stdout_lines | select('match', '^Inst ') | list }}"
+    # Removals are the dangerous class: a resolver working around a hold can
+    # decide to REMOVE the pinned package instead of upgrading it. `Remv haproxy-otel`
+    # would un-divert /usr/sbin/haproxy and the LB never comes back.
+    os_update_removals: "{{ os_update_sim.stdout_lines | select('match', '^(Remv|Purg) ') | list }}"
+
+- name: Existing package holds (someone else's pins — we must restore them verbatim)
+  ansible.builtin.command:
+    argv: [apt-mark, showhold]
+  register: os_update_holds_cmd
+  changed_when: false
+  check_mode: false
+
+- name: Newest installed kernel vs the running one
+  # A host can need a reboot with ZERO pending packages (kernel installed by an
+  # earlier run/unattended-upgrade but never booted) — proven live on
+  # us-omicron-lw-haproxy-public-01 (running 110, 124 installed, 134 available).
+  ansible.builtin.shell:
+    executable: /bin/bash
+    cmd: |
+      set -o pipefail
+      ls -1 /boot/vmlinuz-* 2>/dev/null \
+        | sed 's|.*/vmlinuz-||' \
+        | sort -V \
+        | tail -1
+  register: os_update_newest_kernel_cmd
+  changed_when: false
+  check_mode: false
+
+- name: Is a reboot flagged by the package manager
+  ansible.builtin.stat:
+    path: /var/run/reboot-required
+  register: os_update_reboot_flag
+  check_mode: false
+
+- name: Free space on /boot
+  ansible.builtin.shell:
+    executable: /bin/bash
+    cmd: |
+      set -o pipefail
+      df -Pm /boot | awk 'NR==2 {print $4}'
+  register: os_update_boot_free_cmd
+  changed_when: false
+  check_mode: false
+
+- name: Derive the plan
+  ansible.builtin.set_fact:
+    os_update_holds_before: "{{ os_update_holds_cmd.stdout_lines | default([]) }}"
+    os_update_newest_kernel: "{{ os_update_newest_kernel_cmd.stdout | trim }}"
+    os_update_boot_free_mb: "{{ os_update_boot_free_cmd.stdout | trim | int }}"
+    os_update_needed: "{{ (os_update_pending | length) > 0 }}"
+    # Two INDEPENDENT conditions, both first-class:
+    #   - the package manager asked for a reboot, OR
+    #   - a newer kernel is installed than the one we booted, OR
+    #   - the upgrade we are about to run installs a kernel.
+    os_update_reboot_needed: >-
+      {{ os_update_reboot_flag.stat.exists
+         or ((os_update_newest_kernel_cmd.stdout | trim) not in ['', ansible_facts.kernel])
+         or ((os_update_pending | select('search', '^Inst linux-image')) | list | length > 0) }}
+
+- name: Guard — /boot must have room to unpack a kernel (a full /boot fails AFTER the drain)
+  ansible.builtin.assert:
+    that: (os_update_boot_free_mb | int) >= (os_update_boot_free_min_mb | int)
+    fail_msg: >-
+      /boot has only {{ os_update_boot_free_mb }} MB free (need
+      {{ os_update_boot_free_min_mb }}). Reclaim it first — do not drain a host we
+      then cannot upgrade.

--- a/ansible/collections/maestra/infra/roles/os_update/tasks/reboot.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/reboot.yml
@@ -1,0 +1,63 @@
+---
+# The host is drained and the drain is persistent across the reboot (that is the
+# contract drain.yml must satisfy) — so a reboot here does not put it back into
+# rotation behind our back.
+#
+# Connection notes: these hosts are reached through a `tsh` ProxyCommand, so
+# "reachable again" means the Teleport agent has re-registered with the proxy, not
+# merely that sshd is listening. ansible.builtin.reboot re-runs the ProxyCommand on
+# each retry, so it converges — but post_reboot_delay must cover agent
+# re-registration or the first probes burn on "node not found".
+#
+# The play runs with strategy: linear and mitogen disabled: mitogen's connection
+# multiplexer does not survive reboot/wait_for_connection.
+
+- name: Reboot
+  ansible.builtin.reboot:
+    reboot_timeout: "{{ os_update_reboot_timeout | int }}"
+    post_reboot_delay: "{{ os_update_post_reboot_delay | int }}"
+    connect_timeout: "{{ os_update_connect_timeout | int }}"
+    msg: "os-update {{ os_update_run_url }} (issues-maestra#1104)"
+  register: os_update_reboot_result
+
+- name: Record that we rebooted
+  ansible.builtin.set_fact:
+    os_update_rebooted: true
+
+- name: Wait for systemd to finish booting
+  ansible.builtin.command:
+    argv: [systemctl, is-system-running, --wait]
+  register: os_update_systemd_state
+  # `degraded` = booted, but some unit failed. That is NOT a reason to abort here:
+  # the units we deliberately masked for the drain (haproxy / keepalived / frr) can
+  # legitimately colour the system degraded. verify.yml is what decides whether the
+  # host is healthy; this task only proves the boot finished.
+  failed_when: os_update_systemd_state.stdout not in ['running', 'degraded']
+  changed_when: false
+  check_mode: false
+
+- name: Show failed units when degraded
+  ansible.builtin.command:
+    argv: [systemctl, list-units, --state=failed, --no-legend, --no-pager]
+  register: os_update_failed_units
+  changed_when: false
+  check_mode: false
+  when: os_update_systemd_state.stdout == 'degraded'
+
+- name: Failed units after boot
+  ansible.builtin.debug:
+    var: os_update_failed_units.stdout_lines
+  when: os_update_systemd_state.stdout == 'degraded'
+
+- name: Confirm we booted the kernel we installed
+  ansible.builtin.setup:
+    gather_subset: [min]
+
+- name: Kernel after reboot
+  ansible.builtin.assert:
+    that: ansible_facts.kernel == os_update_newest_kernel
+    fail_msg: >-
+      Booted {{ ansible_facts.kernel }} but the newest installed kernel is
+      {{ os_update_newest_kernel }} — GRUB booted an older entry. Investigate before
+      putting this host back into rotation.
+    success_msg: "Booted {{ ansible_facts.kernel }} (newest installed)."

--- a/ansible/collections/maestra/infra/roles/os_update/tasks/silence.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/silence.yml
@@ -1,0 +1,37 @@
+---
+# One Alertmanager silence PER matcher set. Matchers WITHIN a single silence are
+# ANDed — folding `instance=<host>` AND `alertname=BgpPeerDown` AND
+# `node_group=<peer's group>` into one silence produces a silence that matches
+# NOTHING, and the alerts we most need to suppress are the ones that fire on the
+# SURVIVING peer (BgpPeerDown) and on the far side (StrongSwanIKETunnelDown on the
+# EC2 hubs), whose `instance` is not ours.
+
+- name: Invariant — the dead-man window must expire before the stranded-drain alert fires
+  # OsUpdateHostStrandedDrain has `for: 30m`. If the silence outlived it, the safety
+  # net that detects "a runner died and left this host drained" would be silenced by
+  # the very run that stranded the host.
+  ansible.builtin.assert:
+    that: (os_update_silence_minutes | int) < 30
+    fail_msg: "os_update_silence_minutes must stay below OsUpdateHostStrandedDrain's for: (30m)."
+
+- name: Create the maintenance silences
+  ansible.builtin.uri:
+    url: "{{ os_update_am_url }}/api/v2/silences"
+    method: POST
+    body_format: json
+    body:
+      matchers: "{{ item }}"
+      startsAt: "{{ '%Y-%m-%dT%H:%M:%S.000Z' | strftime(ansible_facts.date_time.epoch | int) }}"
+      endsAt: "{{ '%Y-%m-%dT%H:%M:%S.000Z' | strftime((ansible_facts.date_time.epoch | int) + (os_update_silence_minutes | int) * 60) }}"
+      createdBy: "gha-os-update"
+      comment: "OS update issues-maestra#1104 host={{ inventory_hostname }} run={{ os_update_run_url }}"
+    status_code: 200
+  delegate_to: localhost
+  become: false
+  check_mode: false
+  loop: "{{ os_update_silence_sets }}"
+  register: os_update_silence_post
+
+- name: Remember the silence IDs so `always` can drop them
+  ansible.builtin.set_fact:
+    os_update_silence_ids: "{{ os_update_silence_post.results | map(attribute='json.silenceID') | list }}"

--- a/ansible/collections/maestra/infra/roles/os_update/tasks/unsilence.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/unsilence.yml
@@ -1,0 +1,29 @@
+---
+# Runs in `always`. An already-expired silence is not an error — but a failure to
+# reach Alertmanager IS worth showing, so we surface it rather than swallowing it.
+# We expire the silences we created; if the runner is killed the endsAt dead-man
+# expires them anyway.
+
+- name: Expire the maintenance silences
+  ansible.builtin.uri:
+    url: "{{ os_update_am_url }}/api/v2/silence/{{ item }}"
+    method: DELETE
+    status_code: [200, 404, 500]
+  delegate_to: localhost
+  become: false
+  check_mode: false
+  loop: "{{ os_update_silence_ids | default([]) }}"
+  register: os_update_unsilence
+  failed_when: false
+
+- name: Report any silence we could not expire (the dead-man endsAt still covers us)
+  ansible.builtin.debug:
+    msg: >-
+      Could not expire silence {{ item.item }} (status {{ item.status | default('?') }});
+      it expires on its own in <= {{ os_update_silence_minutes }} min.
+  loop: "{{ os_update_unsilence.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item | default('') }}"
+  when:
+    - item.status is defined
+    - item.status not in [200, 404]

--- a/docs/ansible-os-update.md
+++ b/docs/ansible-os-update.md
@@ -1,0 +1,143 @@
+# Rolling OS update — the shared workflow and the per-repo contract
+
+`issues-maestra#1104`. Patches the pet VMs (haproxy farms, NAT gateways, VPN hosts):
+`apt dist-upgrade` + kernel + reboot, **one host at a time**, each host **drained out
+of rotation first** and **proven healthy** before the next one is touched.
+
+Kubernetes nodes are not in scope — Deckhouse patches those.
+
+## Shape
+
+| piece | where | what it knows |
+|---|---|---|
+| `ansible-os-update.yml` | this repo, `.github/workflows/` | sequencing: enumerate → plan → per-host `apply` matrix (`max-parallel: 1`, `fail-fast`) |
+| `maestra.infra.os_update` role | this repo, `ansible/collections/maestra/infra/` | the generic half: plan, silences, holds, apt, reboot, kernel GC, drain marker |
+| `ansible/tasks/os-update/*.yml` | **each consumer repo** | the role-specific half: what "in rotation" means for haproxy vs nat-gw vs vpn |
+
+The consumer repo installs the role as a Galaxy collection from this repo (public, so no
+CI auth is involved — same as the other public roles already in `requirements.yml`):
+
+```yaml
+collections:
+  - name: https://github.com/maestra-io/github-actions.git#/ansible/collections/maestra/infra/
+    type: git
+    version: v1.2.0
+```
+
+## Why GitHub Actions owns the host sequencing
+
+`teleport-actions/auth` mints **one SSH certificate per job**, at job start. A 12-host
+farm at ~14 min/host is ~2.5 h, so a single-job `serial: 1` run dies with
+`ssh: cert has expired` on every remaining host at once. haproxy-maestra already carries
+that scar (`deploy.yml`: *"rolling_interval=180s stretches the apply past the Teleport SSH
+session lifetime — run 25733140071 lost the API tunnel ~16 minutes into [2/4]"*).
+
+One job per host ⇒ a fresh certificate per host, **"Re-run failed jobs" is the resume
+button** (it replays the failed host and everything `fail-fast` cancelled, in order), and
+omega gets a per-host approval gate for free.
+
+The per-host jobs keep ansible-run's **farm-level** concurrency group, so an os-update can
+never interleave with a config deploy of the same farm — a deploy landing mid-drain would
+cheerfully unmask the `keepalived`/`haproxy` unit we just masked.
+
+## The three invariants
+
+1. **A drain must survive the reboot.** Otherwise the reboot *is* the undrain: the host
+   comes up serving while `verify` is still polling. Runtime-only state (`disable frontend`
+   on the haproxy admin socket, `bgp graceful-shutdown` in the running config) does **not**
+   qualify. Mask the unit, or drain in a plane that persists.
+2. **A drain is proven from the consumer's side.** Not "we applied the config" — but *the
+   NAT gateway now has one nexthop and it isn't us*, *Route53 no longer answers with our IP*,
+   *established sessions on this host fell to zero*.
+3. **Every gate fails closed.** An empty probe result is a failure, not a pass. Every
+   read-only probe carries `check_mode: false`, because `command`/`shell`/`apt` are *skipped*
+   under `--check`, leaving registers undefined and asserts vacuously green. The dry run is
+   `mode: plan`, never `--check`.
+
+## The contract each consumer repo implements
+
+`ansible/tasks/os-update/`:
+
+| file | runs | must | must not |
+|---|---|---|---|
+| `vars.yml` | always | set `os_update_peers`, `os_update_farm`, `os_update_pinned_extra`, `os_update_silence_sets` | mutate anything |
+| `preflight.yml` | always, immediately before the drain | assert **every peer** healthy with a live probe (`delegate_to`), and this host safe to reboot | `ignore_errors`, `failed_when: false`, warn-and-continue |
+| `drain.yml` | apply | take the host out of rotation **persistently**, then **prove it from the consumer side** | prove it by "the command succeeded"; `sleep` instead of poll |
+| `verify.yml` | apply, after reboot, **before** undrain | prove the host is healthy again, with `until`/`retries` | undrain; touch the peer |
+| `undrain.yml` | **`always`** | put it back, idempotently, safe on a host that was never drained | fail silently |
+| `settle.yml` | apply, after undrain | prove traffic is actually flowing and the pair is redundant again | be a `sleep` |
+
+`os_update_silence_sets` is a **list of lists**: each element becomes its **own** silence.
+Matchers *within* one silence are ANDed — folding `instance=<host>` and
+`alertname=BgpPeerDown` and `node_group=<peer's group>` into a single silence yields a
+silence that matches nothing, and the alerts that most need suppressing are the ones firing
+on the **surviving peer** and on the **far end**, whose `instance` is not ours.
+
+## Update payload
+
+`apt-get dist-upgrade`, with **dpkg holds** on the IaC-owned packages: `teleport` (its
+postinst restarts the very agent we are connected through), `frr`, `consul`, plus whatever
+the consumer adds (`haproxy`, `haproxy-otel` — custom builds, not from the archive).
+
+A hold is not enough on its own: apt may satisfy a dependency by **removing** a held
+package, and `Remv haproxy-otel` un-diverts `/usr/sbin/haproxy` and the LB never comes back.
+So after the holds are applied the upgrade is re-simulated and a **tripwire** asserts that no
+pinned package appears as `Inst`, `Remv` **or** `Purg`.
+
+Reboot is decided by three independent signals: `/var/run/reboot-required`, *newest installed
+kernel ≠ running kernel* (a host can need a reboot with zero pending packages), and *the
+upgrade installs a `linux-image-*`*.
+
+Before any reboot the role sets `GRUB_RECORDFAIL_TIMEOUT` — without it, a headless VM that
+fails to boot once waits **forever** in the GRUB menu (`GRUB_TIMEOUT=0` +
+`GRUB_TIMEOUT_STYLE=hidden` and no recordfail timeout is the current state of these boxes),
+turning a recoverable failed reboot into a Proxmox-console rescue.
+
+## When a run dies mid-drain
+
+A cancelled runner never executes `always`. Three layers, of which only the first is a gate:
+
+1. **The Alertmanager silence is the interlock.** It lives off-box and carries a dead-man
+   `endsAt`. `guards.yml` refuses to start if another host in the contour holds an open
+   os-update silence. (The on-host metric is *not* usable as the interlock: it disappears
+   during the reboot, so `count(...) == 0` evaluates over an empty vector and fails **open**
+   in exactly the window it exists for.)
+2. **The on-disk marker** `/var/lib/os-update/drained.json` — a re-run reads it, knows the
+   host is already drained, and finishes the job idempotently.
+3. **`OsUpdateHostStrandedDrain`** fires on the marker's metric outliving the silence
+   (`silence_minutes` < the alert's `for:` — asserted in code, so the safety net can never be
+   silenced by the run that stranded the host).
+
+Escape hatch: `mode: undrain-only` (optionally `host_limit: <host>`). It skips preflight on
+purpose — the peer gates there are exactly what fails in the scenario the hatch exists for.
+
+## Running it
+
+```bash
+# read-only, whole farm: pending packages, reboot decision, peer health, /boot headroom
+gh workflow run os-update.yml -f environment=omicron -f role=nat_gateway -f mode=plan
+
+# one host, for real
+gh workflow run os-update.yml -f environment=omicron -f role=nat_gateway \
+  -f mode=apply -f host_limit=us-omicron-lw-nat-gw-02
+
+# the whole farm, one host at a time, stopping at the first failure
+gh workflow run os-update.yml -f environment=omicron -f role=nat_gateway -f mode=apply
+```
+
+Idempotency is a derived property, not a state file: a host with an empty upgrade
+simulation, no `reboot-required` and the newest kernel already running is **never drained**
+and never rebooted — the job is green in ~60 s. So re-running after a partial sweep is safe
+and cheap.
+
+## Not covered by this workflow
+
+- **`eu-omega-lw-*`** — out of scope for v1. The EU haproxy `kube-cdp` pair is owned by
+  GitLab `development/ansible` (Octopus), and EU nat-gw's keepalived + AWS route-failover
+  scripts are **not in IaC at all** (a full playbook run there would render `keepalived.conf`
+  with no `vrrp_instance` and drop the VIPs). Separate issue.
+- **CVEs in the pinned packages themselves** (teleport, frr, haproxy) — they stay. Bumping
+  them is each component's own upgrade path.
+- **ESM-only CVEs.** Ubuntu Pro is not attached anywhere in the org, so a set of findings
+  cannot be cleared by any amount of `dist-upgrade`. That is a procurement decision, not a
+  workflow feature.


### PR DESCRIPTION
Shared machinery for issues-maestra#1104 — rolling `apt dist-upgrade` + kernel + reboot across the pet VMs (haproxy farms, NAT gateways, VPN hosts), one host at a time, each drained out of rotation and proven healthy before the next is touched.

## What is here

| piece | what it knows |
|---|---|
| `.github/workflows/ansible-os-update.yml` | sequencing: `enumerate` -> `plan` -> per-host `apply` matrix (`max-parallel: 1`, `fail-fast`) |
| `ansible/collections/maestra/infra/` (role `os_update`) | the generic half: plan, Alertmanager silences, dpkg holds, apt, reboot, kernel GC, drain marker |
| `.github/workflows/ansible-run.yml` | new `tbot_tunnels` input (generalises the hard-coded Vault tunnel) |
| `docs/ansible-os-update.md` | the normative per-repo contract |

The role-specific half (what "in rotation" *means* for haproxy vs nat-gw vs vpn) is a task-file contract implemented in each consumer repo: `preflight / drain / verify / undrain / settle`.

## Why GitHub Actions owns the host sequencing, not `serial: 1`

`teleport-actions/auth` mints **one SSH certificate per job**, at job start. A 12-host farm at ~14 min/host is ~2.5 h — past any TTL the bot role grants, and the cert dies on every remaining host at the same instant. haproxy-maestra already has this on record (`deploy.yml`: *rolling_interval=180s stretches the apply past the Teleport SSH session lifetime — run 25733140071 lost the API tunnel ~16 minutes into [2/4]*).

One job per host ⇒ fresh cert per host, **"Re-run failed jobs" is the resume button**, and omega gets a per-host approval gate for free. The per-host jobs keep ansible-run's **farm-level** concurrency group, so an os-update can never interleave with a config deploy of the same farm (which would happily unmask the unit we just masked to drain the host).

## The three invariants

1. **A drain must survive the reboot.** Otherwise the reboot *is* the undrain: the host comes back serving while `verify` is still polling. Runtime-only state (`disable frontend`, `bgp graceful-shutdown` in the running config) does not qualify.
2. **A drain is proven from the consumer's side** — the NAT gateway now has one nexthop and it is not us; Route53 no longer answers with our IP; established sessions fell to zero. Not "the command succeeded".
3. **Gates fail closed**, and every read-only probe carries `check_mode: false` — `command`/`shell`/`apt` are *skipped* under `--check`, leaving registers undefined and asserts vacuously green. So the dry run is `mode: plan`, never `--check`.

## Validated live (us-omicron-lw nat-gw pair, read-only)

- `mode=plan` green on both hosts: **37/38 tasks ok, 0 failed** — VRRP state via the exporter, track script, BGP peers/prefixes, RIB-vs-FIB, dataplane, Kea HA, single VIP holder.
- Plan output: kernel `6.8.0-124` running, `6.8.0-134` already installed but never booted, 30 pending packages, `/boot` 703 MB free.
- **The holds earn their keep**: without them `apt dist-upgrade` on these hosts would pull `teleport 18.8.2 -> 18.10.0` (its postinst restarts the very agent ansible rides on) and `consul 1.22.6 -> 2.0.2` (a major bump) on the haproxy boxes. `Remv`/`Purg`: none anywhere.
- Two bugs were caught by that local run and fixed here: the RIB/FIB gate counted the kernel side with `wc -l` (ECMP prints one line per nexthop — 16 routes, 58 lines, so the gate failed on a healthy host; now `ip -j | jq length`), and fact refs used `ansible_kernel` while every consumer repo sets `inject_facts_as_vars = False` (now `ansible_facts.kernel`).

## Not in scope

`eu-omega-lw-*` (the EU haproxy kube-cdp pair is owned by GitLab `development/ansible` + Octopus; EU nat-gw's keepalived and AWS route-failover scripts are not in IaC at all). CVEs inside the pinned packages. ESM-only CVEs — Ubuntu Pro is not attached anywhere in the org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds reusable machinery for safe, rolling OS updates across pet VMs:

- New GitHub Actions workflow for host discovery, planning, and serialized per-host updates with fresh Teleport SSH certificates.
- New `maestra.infra.os_update` Ansible role covering Alertmanager silences, persistent draining, package holds, simulated and real upgrades, reboot verification, kernel cleanup, and recovery markers.
- Generalized `tbot_tunnels` support for reusable Ansible runs.
- Documentation defining consumer hooks for preflight, drain, verification, undrain, and settle operations.
- Fail-closed health checks, consumer-side drain verification, package-upgrade tripwires, and GRUB record-failure timeout protection.

## Breaking Changes

No explicit breaking changes. Consumers must implement the documented OS-update hook contract and provide compatible inventory/group configuration to use the new workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->