### PR TITLE
fix(os_update): collection metadata (license, requires_ansible, README)

### DIFF
--- a/ansible/collections/maestra/infra/README.md
+++ b/ansible/collections/maestra/infra/README.md
@@ -1,0 +1,43 @@
+# maestra.infra
+
+Shared Ansible content for Maestra infrastructure repos.
+
+## `os_update`
+
+The **generic half** of the rolling OS-update workflow (`issues-maestra#1104`): plan,
+Alertmanager maintenance silences, dpkg holds, `apt dist-upgrade`, reboot, kernel GC,
+and the drain marker.
+
+The **role-specific half** — what "in rotation" actually *means* for a haproxy farm vs
+a NAT gateway vs a VPN host — is a task-file contract each consumer repo implements at
+`ansible/tasks/os-update/{vars,preflight,drain,verify,undrain,settle}.yml`.
+
+Full contract and rationale:
+[docs/ansible-os-update.md](https://github.com/maestra-io/github-actions/blob/main/docs/ansible-os-update.md).
+
+## Install
+
+The repo is public, so no CI auth is involved:
+
+```yaml
+# ansible/requirements.yml
+collections:
+  - name: https://github.com/maestra-io/github-actions.git#/ansible/collections/maestra/infra/
+    type: git
+    version: main
+```
+
+```yaml
+# ansible/playbooks/os-update.yml
+- name: OS update
+  hosts: all
+  serial: 1
+  any_errors_fatal: true
+  strategy: linear      # NOT mitogen — it does not survive reboot/wait_for_connection
+  become: true
+  roles:
+    - role: maestra.infra.os_update
+```
+
+Driven one host per GitHub job by
+`maestra-io/github-actions/.github/workflows/ansible-os-update.yml`.

--- a/ansible/collections/maestra/infra/galaxy.yml
+++ b/ansible/collections/maestra/infra/galaxy.yml
@@ -11,7 +11,8 @@ description: >-
   Alertmanager silences, drain marker). The role-specific half (preflight /
   drain / verify / undrain) is implemented by each consumer repo as a task-file
   contract — see docs/ansible-os-update.md.
-license_expression: MIT
+license:
+  - MIT
 tags:
   - infrastructure
   - patching

--- a/ansible/collections/maestra/infra/meta/runtime.yml
+++ b/ansible/collections/maestra/infra/meta/runtime.yml
@@ -1,0 +1,7 @@
+---
+# Declares the minimum ansible-core this collection supports. Without it every
+# consumer's ansible-lint run prints
+#   "[WARNING]: maestra.infra:1.0.0 does not have requires_ansible metadata".
+# 2.16 is the floor for the modules used here (ansible.builtin.reboot with
+# post_reboot_delay, systemd masked:, apt lock_timeout).
+requires_ansible: ">=2.16"


### PR DESCRIPTION
Follow-up to #22. Three warnings that every consumer of `maestra.infra` printed on every ansible-lint run:

- `license_expression` is not understood by the ansible-galaxy CI runs on — it warned *"Found unknown keys in collection galaxy.yml"*. Replaced with the `license` list.
- No `requires_ansible` metadata → *"maestra.infra:1.0.0 does not have requires_ansible metadata"*. Added `meta/runtime.yml` with `>=2.16`, the real floor for the modules used here (`reboot` with `post_reboot_delay`, `systemd` `masked:`, `apt` `lock_timeout`).
- `galaxy.yml` pointed at a `README.md` that did not exist. Written.

Warnings, not failures — but they were printed in the CI log of three repos on every run, which is exactly how a real warning gets missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated `maestra.infra` Galaxy metadata to use the supported `license: [MIT]` format.
- Added runtime metadata requiring Ansible Core `>=2.16`.
- Added collection documentation with installation guidance and `os_update` usage examples.

## Breaking Changes

- Consumers must use Ansible Core 2.16 or newer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->