### PR TITLE
fix(ansible-run): read-only checks must not share the mutating concurrency lane

### DIFF
--- a/.github/workflows/ansible-os-update.yml
+++ b/.github/workflows/ansible-os-update.yml
@@ -224,6 +224,14 @@ jobs:
       use_mitogen: false
       no_hosts_fail_on_apply: true
       certificate_ttl: 30m
+      # The plan is read-only, but it deliberately does NOT use --check (command /
+      # shell / apt are skipped there, which would leave every probe register
+      # undefined). So it cannot be recognised as read-only from inside ansible-run,
+      # and without its own lane it would sit in the farm's MUTATING concurrency
+      # group — where any Renovate PR check landing in the group evicts it, because
+      # GitHub keeps at most one pending job per group. That is how run 29359006993
+      # was cancelled before it ever reached a host.
+      concurrency_suffix: "-osupdate-plan"
       tbot_tunnels: |
         app=${{ inputs.alertmanager_app }} listen=9093
       extra_run_args: >-

--- a/.github/workflows/ansible-run.yml
+++ b/.github/workflows/ansible-run.yml
@@ -93,6 +93,15 @@ on:
         required: false
         type: string
         default: ""
+      concurrency_suffix:
+        description: >-
+          Appended to the concurrency group. Lets a caller opt out of the farm-wide
+          mutating lane when its run is read-only in effect but does not use --check
+          (the os-update `plan` job — command/shell/apt are SKIPPED under check mode,
+          so its probes must run for real). Leave empty for anything that mutates.
+        required: false
+        type: string
+        default: ""
       tbot_tunnels:
         description: >-
           Generic Teleport app tunnels for the play, one `app=<teleport-app> listen=<port>`
@@ -195,7 +204,25 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.gh_environment }}
     concurrency:
-      group: ansible-${{ inputs.region }}-${{ inputs.environment }}-${{ inputs.site }}${{ inputs.inventory_group_suffix }}
+      # Two classes, deliberately NOT one group.
+      #
+      # MUTATING runs (deploys, os-update applies) share the farm group: they must
+      # never interleave. A config deploy landing mid-drain would happily unmask the
+      # keepalived/haproxy unit an os-update just masked to take the host out.
+      #
+      # READ-ONLY runs (--check: the PR plan matrix) get their own `-check` group.
+      # They used to share the farm group, which meant any PR check — including the
+      # three Renovate PRs that happen to be open on a Tuesday — would land in the
+      # group and CANCEL a pending os-update job, because GitHub keeps at most one
+      # pending job per group and evicts the older one. That is how run 29359006993
+      # died. A read-only check has no reason to be exclusive with anything.
+      #
+      # concurrency_suffix is the escape hatch for a caller that needs its own lane
+      # (the os-update `plan` job uses it: it runs with check_mode:false — command/
+      # shell/apt are skipped under --check — so it is read-only in effect but cannot
+      # be recognised as such from here).
+      group: >-
+        ansible-${{ inputs.region }}-${{ inputs.environment }}-${{ inputs.site }}${{ inputs.inventory_group_suffix }}${{ inputs.check_mode && '-check' || '' }}${{ inputs.concurrency_suffix }}
       cancel-in-progress: false
     env:
       ANSIBLE_FORCE_COLOR: "1"


### PR DESCRIPTION
fix(ansible-run): read-only checks must not share the mutating concurrency lane

Found the moment the first os-update plan ran for real (run 29359006993): it was
CANCELLED before it reached a host. Not by a deploy — by three Renovate PRs
(ansible-14.x, markupsafe, jinja2) whose check-mode jobs landed in the same
farm-level concurrency group. GitHub keeps at most ONE pending job per group and
evicts the older one, so any open PR touching an ansible repo could silently kill
an in-flight fleet patch.

The interlock we actually need is between MUTATING runs: a config deploy landing
mid-drain would cheerfully unmask the keepalived/haproxy unit an os-update just
masked to take a host out of rotation. A read-only --check plan has no reason to
be exclusive with anything.

So the group now splits by class:
  * check_mode: true  -> ansible-<farm>-check   (PR plans; still cancel each other,
                                                 which is the pre-existing behaviour)
  * check_mode: false -> ansible-<farm>          (deploys AND os-update applies —
                                                 mutually exclusive, as before)

Plus a concurrency_suffix input for the caller that is read-only in EFFECT but
cannot say so with --check. The os-update `plan` job is exactly that case: it runs
check_mode:false on purpose, because command/shell/apt are SKIPPED under --check and
every probe register would come back undefined — a green plan that proved nothing.
It now takes its own `-osupdate-plan` lane.

os-update APPLY jobs deliberately keep the bare farm group: they must stay exclusive
with deploys.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
