### PR TITLE
fix(os-update): the plan job is farm-wide by design, exempt it from the one-host guard

### DIFF
--- a/.github/workflows/ansible-os-update.yml
+++ b/.github/workflows/ansible-os-update.yml
@@ -205,6 +205,14 @@ jobs:
   # Read-only across the WHOLE group: pending packages, reboot decision, /boot
   # headroom, peer health, and "is anyone already drained". Never gated — you
   # approve `apply` after you have read the plan.
+  #
+  # This job is the ONE place the playbook's "one host per job" guard must be
+  # relaxed: the guard exists to stop a human running a fleet-wide APPLY by hand
+  # (which would skip the GH-level fail-fast, per-host approval and artifact trail),
+  # but a plan is read-only and is deliberately farm-wide — you want to see every
+  # host's pending packages in one table. Without os_update_allow_multi the guard
+  # fires on the plan itself and the run dies before it reaches a host (run
+  # 29360255290).
   plan:
     needs: enumerate
     uses: ./.github/workflows/ansible-run.yml
@@ -237,6 +245,7 @@ jobs:
       extra_run_args: >-
         -e os_update_mode=plan
         -e os_update_am_url=http://127.0.0.1:9093
+        -e os_update_allow_multi=true
         ${{ inputs.extra_run_args }}
       artifact_name: os-update-plan-${{ inputs.region }}-${{ inputs.environment }}-${{ inputs.site }}${{ inputs.inventory_group_suffix }}-${{ github.run_number }}
 


### PR DESCRIPTION
The playbook guards against being run fleet-wide by hand — that would skip the GitHub-level fail-fast, the per-host approval and the per-host artifact trail.

But the `plan` job is **deliberately farm-wide and read-only**: the point of it is to see every host's pending packages, reboot decision, `/boot` headroom and peer health in one table *before* approving the apply.

So the guard fired on the plan itself and the first real run died before it ever reached a host ([run 29360255290](https://github.com/maestra-io/maestra-nat-gateway/actions/runs/29360255290): *2 hosts in the play*). The plan job now passes `os_update_allow_multi=true`; `apply` jobs still run strictly one host per job.

Everything upstream of the guard worked on that run, which is the useful part: the tbot **Alertmanager app tunnel came up** (`tunnel for alertmanager is up on 127.0.0.1:9093`), so the Teleport role added in maestra-io/fluxcd#5212 is doing its job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)