### PR TITLE
fix(os_update): lineinfile validate needs a %s placeholder — drop it

### DIFF
--- a/ansible/collections/maestra/infra/roles/os_update/tasks/boot_safety.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/boot_safety.yml
@@ -17,7 +17,6 @@
     regexp: '^#?\s*GRUB_RECORDFAIL_TIMEOUT='
     line: "GRUB_RECORDFAIL_TIMEOUT={{ os_update_grub_recordfail_timeout | default(5) }}"
     state: present
-    validate: /bin/true
   register: os_update_grub
 
 - name: Regenerate grub.cfg


### PR DESCRIPTION
`ansible.builtin.lineinfile` rejects a `validate` command that has no `%s`:

```
validate must contain %s: /bin/true
```

It was a validates-nothing placeholder anyway. `/etc/default/grub` is sanity-checked by `update-grub` in the very next task, which is the real validation.

Caught on the first live apply ([run 29360602654](https://github.com/maestra-io/maestra-nat-gateway/actions/runs/29360602654), `us-omicron-lw-nat-gw-02`).

**The failure is worth keeping for what it proved.** The host was already **drained** when this blew up, and the rescue/always path did exactly its job:

```
Record the failure -> Restore the pre-existing hold set -> UNDRAIN -> Unmask and start keepalived
-> "keepalived unmasked and running, VRRP state 1 (1=BACKUP 2=MASTER)"
-> Clear the drain marker -> Expire the maintenance silences -> Fail the job
```

The host came back **healthy and in rotation**, the fleet stopped at the first failure, and nothing was stranded. That is the whole safety design working on a real failure rather than a rehearsed one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)