### PR TITLE
feat(os-update): re-scan patched hosts into SOC + fix the stale kernel gate

### DIFF
--- a/.github/workflows/ansible-os-update.yml
+++ b/.github/workflows/ansible-os-update.yml
@@ -107,6 +107,15 @@ on:
         required: false
       PROXMOX_MONITORING_PASSWORD:
         required: false
+      SOC_DISPATCH_TOKEN:
+        description: >-
+          Token with actions:write on maestra-io/soc, used to kick a vulnerability
+          re-scan of exactly the hosts we just patched. The job's own GITHUB_TOKEN
+          cannot do this: it is scoped to the calling repo, and the SOC scan's
+          database secret lives in the soc repo (so `secrets: inherit` on a reusable
+          workflow would not carry it either). Absent = the re-scan is SKIPPED with a
+          loud warning and the exact command to run by hand — never a silent green.
+        required: false
 
 permissions:
   contents: read
@@ -287,3 +296,57 @@ jobs:
       # omicron is not. Never invent an environment name for omicron — GitHub would
       # silently create it WITHOUT protection rules, which reads like a gate and isn't one.
       gh_environment: ${{ inputs.environment == 'omega' && format('{0}-{1}-{2}', inputs.region, inputs.environment, inputs.site) || '' }}
+
+  # Close the loop. The fleet is not "patched" because `uname -r` changed — it is
+  # patched when the vulnerability scanner AGREES. So re-scan exactly the hosts we
+  # just touched and push the findings to the SOC portal, instead of leaving the
+  # board stale until the next weekly sweep (Monday 05:00 UTC).
+  #
+  # This is also the only end-to-end check on the update payload itself: the kernel
+  # gate proves we booted a newer kernel, but only the scan proves the CVEs that put
+  # this fleet on the SOC board in the first place are actually gone.
+  soc-rescan:
+    needs: [enumerate, apply]
+    if: ${{ inputs.mode == 'apply' && needs.apply.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Re-scan the patched hosts and push to SOC
+        env:
+          HOSTS: ${{ needs.enumerate.outputs.hosts }}
+          SOC_TOKEN: ${{ secrets.SOC_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+          LIST="$(printf '%s' "${HOSTS}" | jq -r 'join(",")')"
+
+          if [ -z "${SOC_TOKEN}" ]; then
+            # Loud, never silently green. A skipped re-scan means SOC keeps showing the
+            # PRE-PATCH findings, and the next person to look at the board concludes the
+            # fleet is still vulnerable — or, worse, that the patch run did nothing.
+            echo "::warning::SOC re-scan SKIPPED — no SOC_DISPATCH_TOKEN. The hosts ARE patched, but the SOC board still shows pre-patch findings until someone runs: gh workflow run vuln-scan.yaml --repo maestra-io/soc -f hosts=${LIST}"
+            {
+              echo "### SOC re-scan SKIPPED — no \`SOC_DISPATCH_TOKEN\`"
+              echo ""
+              echo "The hosts **are** patched, but the SOC board still shows the pre-patch"
+              echo "findings until it is re-scanned. Run it by hand:"
+              echo ""
+              echo "    gh workflow run vuln-scan.yaml --repo maestra-io/soc -f hosts=${LIST}"
+              echo ""
+              echo "To make this automatic: add a fine-grained PAT with **actions: write** on"
+              echo "\`maestra-io/soc\` as the \`SOC_DISPATCH_TOKEN\` secret of this repo."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "Dispatching a SOC vuln-scan for: ${LIST}"
+          GH_TOKEN="${SOC_TOKEN}" gh workflow run vuln-scan.yaml \
+            --repo maestra-io/soc \
+            -f hosts="${LIST}" \
+            -f dry_run=false
+
+          {
+            echo "### SOC re-scan dispatched"
+            echo ""
+            echo "Hosts: \`${LIST}\`"
+            echo ""
+            echo "<https://github.com/maestra-io/soc/actions/workflows/vuln-scan.yaml>"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/ansible/collections/maestra/infra/roles/os_update/tasks/reboot.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/reboot.yml
@@ -49,15 +49,39 @@
     var: os_update_failed_units.stdout_lines
   when: os_update_systemd_state.stdout == 'degraded'
 
-- name: Confirm we booted the kernel we installed
+- name: Re-gather facts (we are on a new kernel now)
   ansible.builtin.setup:
     gather_subset: [min]
 
+- name: Re-read the newest installed kernel
+  # MUST be recomputed here. os_update_newest_kernel was measured during the PLAN,
+  # i.e. BEFORE apt installed anything — so on any host where the upgrade itself
+  # brought in the new kernel, the planned value is already stale by the time we
+  # reboot. Asserting against it fails with the absurd message "booted 6.8.0-134 but
+  # the newest installed is 6.8.0-124" on a host that did exactly the right thing
+  # (that is us-omicron-lw-vpn-01, run 29362013711).
+  ansible.builtin.shell:
+    executable: /bin/bash
+    cmd: |
+      set -o pipefail
+      ls -1 /boot/vmlinuz-* 2>/dev/null | sed 's|.*/vmlinuz-||' | sort -V | tail -1
+  register: os_update_newest_kernel_post
+  changed_when: false
+  check_mode: false
+
 - name: Kernel after reboot
+  # The gate that matters: we must be RUNNING the newest kernel on disk. If GRUB
+  # booted an older entry, the CVEs we just patched are still live and the host must
+  # not go back into rotation.
   ansible.builtin.assert:
-    that: ansible_facts.kernel == os_update_newest_kernel
+    that: ansible_facts.kernel == (os_update_newest_kernel_post.stdout | trim)
     fail_msg: >-
       Booted {{ ansible_facts.kernel }} but the newest installed kernel is
-      {{ os_update_newest_kernel }} — GRUB booted an older entry. Investigate before
-      putting this host back into rotation.
-    success_msg: "Booted {{ ansible_facts.kernel }} (newest installed)."
+      {{ os_update_newest_kernel_post.stdout | trim }} — GRUB booted an older entry.
+      Investigate before putting this host back into rotation.
+    success_msg: "Booted {{ ansible_facts.kernel }} (the newest installed kernel)."
+
+- name: Remember what we ended up on
+  ansible.builtin.set_fact:
+    os_update_newest_kernel: "{{ os_update_newest_kernel_post.stdout | trim }}"
+    os_update_booted_kernel: "{{ ansible_facts.kernel }}"


### PR DESCRIPTION
feat(os-update): re-scan patched hosts into SOC + fix the stale kernel gate

Two things, both surfaced by the first real omicron sweep.

1. The kernel gate compared against a STALE value and failed a host that did
   exactly the right thing. os_update_newest_kernel is measured during the PLAN —
   before apt installs anything — so on any host where the upgrade itself brings in
   the new kernel, the planned value is already out of date by the time we reboot.
   us-omicron-lw-vpn-01 (run 29362013711) booted 6.8.0-134 and the assert declared:
   "Booted 6.8.0-134 but the newest installed kernel is 6.8.0-124 — GRUB booted an
   older entry." Absurd on its face, and it aborted a perfectly good host (the
   rescue path un-drained it correctly, so no harm done).

   The newest-installed kernel is now re-read AFTER the reboot, and the gate keeps
   its real meaning: we must be RUNNING the newest kernel on disk, because if GRUB
   booted an older entry the CVEs we just patched are still live and the host must
   not go back into rotation.

2. A fleet is not "patched" because uname -r changed — it is patched when the
   scanner agrees. The workflow now re-scans exactly the hosts it touched and pushes
   the findings to the SOC portal, instead of leaving the board stale until the next
   weekly sweep (Monday 05:00 UTC). It is also the only end-to-end check on the
   payload: the kernel gate proves we booted something newer, only the scan proves
   the CVEs that put this fleet on the SOC board are gone.

   Auth: this needs a token with actions:write on maestra-io/soc. The job's own
   GITHUB_TOKEN is scoped to the calling repo, and the scan's database secret is a
   REPO secret of maestra-io/soc — so `secrets: inherit` on a reusable workflow
   would not carry it either. Without SOC_DISPATCH_TOKEN the job does not fail the
   run, but it does NOT go quietly green: it emits a ::warning:: and a step-summary
   block with the exact command to run by hand. A silent skip is the failure mode
   worth avoiding here — it leaves the board showing pre-patch findings, and the next
   person reads that as "the sweep did nothing".

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
