### PR TITLE
fix(os_update): drop the run label from os_update_drained — it fired the alert on every clean run

### DIFF
--- a/ansible/collections/maestra/infra/roles/os_update/tasks/marker.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/marker.yml
@@ -54,13 +54,27 @@
               'started': ansible_facts.date_time.iso8601} | to_nice_json }}
 
     - name: Textfile metric (feeds OsUpdateHostStrandedDrain)
+      # NO labels on the gauge. The run URL used to be a label here, and that made the
+      # alert fire on every SUCCESSFUL run: the drain wrote
+      #   os_update_drained{run="https://.../runs/29361170519"} 1
+      # and the clear wrote
+      #   os_update_drained{run=""} 0
+      # An empty label value is dropped by Prometheus, so those are two DIFFERENT
+      # series. The clear never zeroed the first one — it just went stale at 1, and
+      # OsUpdateHostStrandedDrain's `last_over_time(os_update_drained[45m]) == 1` kept
+      # matching it for 45 minutes after the host was healthy and back in rotation.
+      # (That is Rootly #I4bW6B, fired 2026-07-14 on a fleet that was entirely fine.)
+      #
+      # Label-free means write(1) and clear(0) hit the SAME series, which is the only
+      # way last_over_time() can mean what the alert needs it to mean. The run URL
+      # lives in the marker file, which is where the reconcile path reads it from.
       ansible.builtin.copy:
         dest: "{{ node_exporter_textfile_dir }}/os_update.prom"
         mode: "0644"
         content: |
           # HELP os_update_drained 1 while an os-update run holds this host out of rotation.
           # TYPE os_update_drained gauge
-          os_update_drained{run="{{ os_update_run_url }}"} 1
+          os_update_drained 1
 
 - name: Clear the marker
   when: os_update_marker_action == 'clear'
@@ -71,10 +85,11 @@
         state: absent
 
     - name: Zero the metric (deleting the file would leave the last scrape stale)
+      # Same series as the write — no labels. See the comment there for why.
       ansible.builtin.copy:
         dest: "{{ node_exporter_textfile_dir }}/os_update.prom"
         mode: "0644"
         content: |
           # HELP os_update_drained 1 while an os-update run holds this host out of rotation.
           # TYPE os_update_drained gauge
-          os_update_drained{run=""} 0
+          os_update_drained 0


### PR DESCRIPTION
fix(os_update): drop the run label from os_update_drained — it fired the alert on every clean run

OsUpdateHostStrandedDrain paged (Rootly #I4bW6B) on a fleet that was entirely
healthy: keepalived/frr enabled+active everywhere, exactly one VIP holder, ECMP
across both VPN hosts, every drain marker cleared.

The bug was in the metric, not the alert. The drain wrote

    os_update_drained{run="https://github.com/.../runs/29361170519"} 1

and the clear wrote

    os_update_drained{run=""} 0

Prometheus DROPS an empty label value, so those are two different series. The clear
never zeroed the first one — it simply went stale at 1, and the alert's
last_over_time(os_update_drained[45m]) == 1 went on matching it for 45 minutes after
the host was healthy and back in rotation. Proven live:

    last_over_time(os_update_drained[45m]) == 1
      -> {instance="us-omicron-lw-nat-gw-01", run=".../29361170519"} = 1   (stale)
      -> {instance="us-omicron-lw-vpn-01",    run=".../29363028228"} = 1   (stale)
    os_update_drained  (instant)
      -> all three hosts = 0                                                (current)

The gauge is now label-free, so write(1) and clear(0) land on the SAME series and
last_over_time() means what the alert needs it to mean. The run URL stays in
/var/lib/os-update/drained.json, which is where the reconcile path reads it anyway.

A per-run label on a gauge whose whole purpose is "is this still 1?" was never going
to work. The alert did its job — it just caught its own author.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
