### PR TITLE
fix(teleport): retry the tbot auth step instead of reddening the run

### DIFF
--- a/.github/workflows/ansible-os-update.yml
+++ b/.github/workflows/ansible-os-update.yml
@@ -155,8 +155,22 @@ jobs:
         with:
           version: ${{ steps.tp-version.outputs.version }}
 
+      # teleport-actions/auth mints the certificate by running tbot, whose heartbeat
+      # to the proxy intermittently fails ("keepalive ping failed to receive ACK
+      # within timeout") and reds a whole run before a single host is touched. The
+      # first attempt is allowed to fail; the retry decides the job.
       - name: Teleport auth
         id: teleport-auth
+        continue-on-error: true
+        uses: teleport-actions/auth@v2
+        with:
+          proxy: teleport.maestra.io:443
+          token: github-actions-infra-deploy
+          certificate-ttl: 30m
+
+      - name: Teleport auth — retry
+        id: teleport-auth-retry
+        if: steps.teleport-auth.outcome == 'failure'
         uses: teleport-actions/auth@v2
         with:
           proxy: teleport.maestra.io:443
@@ -167,8 +181,8 @@ jobs:
         id: list
         working-directory: ${{ inputs.working_directory }}
         env:
-          TELEPORT_IDENTITY_FILE: ${{ steps.teleport-auth.outputs.identity-file }}
-          TBOT_DEST_DIR: ${{ steps.teleport-auth.outputs.destination-dir }}
+          TELEPORT_IDENTITY_FILE: ${{ steps.teleport-auth.outputs.identity-file || steps.teleport-auth-retry.outputs.identity-file }}
+          TBOT_DEST_DIR: ${{ steps.teleport-auth.outputs.destination-dir || steps.teleport-auth-retry.outputs.destination-dir }}
           TELEPORT_PROXY: teleport.maestra.io:443
           GROUP: ${{ inputs.region }}_${{ inputs.environment }}_${{ inputs.site }}${{ inputs.inventory_group_suffix }}
           HOST_LIMIT: ${{ inputs.host_limit }}

--- a/.github/workflows/ansible-run.yml
+++ b/.github/workflows/ansible-run.yml
@@ -280,8 +280,24 @@ jobs:
         with:
           version: ${{ steps.tp-version.outputs.version }}
 
+      # teleport-actions/auth mints the certificate by running tbot, whose heartbeat
+      # to the proxy intermittently fails ("keepalive ping failed to receive ACK
+      # within timeout") and reds a whole run before a single task has executed.
+      # The first attempt is therefore allowed to fail; the retry is the one that
+      # decides the job. Both steps' outputs are read with `a || b` downstream —
+      # exactly one of them produces an identity.
       - name: Teleport auth (SSH)
         id: teleport-auth
+        continue-on-error: true
+        uses: teleport-actions/auth@v2 # TODO: SHA-pin via Renovate on landing
+        with:
+          proxy: ${{ inputs.teleport_fqdn }}
+          token: ${{ inputs.teleport_join_token }}
+          certificate-ttl: ${{ inputs.certificate_ttl }}
+
+      - name: Teleport auth (SSH) — retry
+        id: teleport-auth-retry
+        if: steps.teleport-auth.outcome == 'failure'
         uses: teleport-actions/auth@v2 # TODO: SHA-pin via Renovate on landing
         with:
           proxy: ${{ inputs.teleport_fqdn }}
@@ -398,7 +414,7 @@ jobs:
         id: mint-proxmox
         if: ${{ inputs.mint_proxmox_token }}
         env:
-          TELEPORT_IDENTITY_FILE: ${{ steps.teleport-auth.outputs.identity-file }}
+          TELEPORT_IDENTITY_FILE: ${{ steps.teleport-auth.outputs.identity-file || steps.teleport-auth-retry.outputs.identity-file }}
           TELEPORT_PROXY: ${{ inputs.teleport_fqdn }}
         run: |
           set -euo pipefail
@@ -438,8 +454,8 @@ jobs:
           # teleport_inventory.py reads TELEPORT_PROXY (tsh ls / cluster name) and
           # TBOT_DEST_DIR (IdentityFile/CertificateFile ssh args); tsh reads
           # TELEPORT_IDENTITY_FILE automatically. Without these, SSH auth fails.
-          TELEPORT_IDENTITY_FILE: ${{ steps.teleport-auth.outputs.identity-file }}
-          TBOT_DEST_DIR: ${{ steps.teleport-auth.outputs.destination-dir }}
+          TELEPORT_IDENTITY_FILE: ${{ steps.teleport-auth.outputs.identity-file || steps.teleport-auth-retry.outputs.identity-file }}
+          TBOT_DEST_DIR: ${{ steps.teleport-auth.outputs.destination-dir || steps.teleport-auth-retry.outputs.destination-dir }}
           TELEPORT_PROXY: ${{ inputs.teleport_fqdn }}
           # optional app-cred passthroughs (empty for repos that don't set them)
           VECTOR_SIEM_BASIC_AUTH_USER: ${{ secrets.VECTOR_SIEM_BASIC_AUTH_USER }}

--- a/.github/workflows/terraform-run.yml
+++ b/.github/workflows/terraform-run.yml
@@ -224,8 +224,22 @@ jobs:
           version: ${{ steps.tp-version.outputs.version }}
           proxy: ${{ inputs.teleport_fqdn }}
 
+      # teleport-actions/auth mints the certificate by running tbot, whose heartbeat
+      # to the proxy intermittently fails ("keepalive ping failed to receive ACK
+      # within timeout") and reds a whole run before any terraform executes. The
+      # first attempt is allowed to fail; the retry decides the job.
       - name: Teleport auth
         id: teleport-auth
+        continue-on-error: true
+        uses: teleport-actions/auth@v2 # TODO: SHA-pin via Renovate on landing
+        with:
+          proxy: ${{ inputs.teleport_fqdn }}
+          token: ${{ inputs.teleport_join_token }}
+          certificate-ttl: 30m
+
+      - name: Teleport auth — retry
+        id: teleport-auth-retry
+        if: steps.teleport-auth.outcome == 'failure'
         uses: teleport-actions/auth@v2 # TODO: SHA-pin via Renovate on landing
         with:
           proxy: ${{ inputs.teleport_fqdn }}
@@ -236,8 +250,8 @@ jobs:
         # HIDDEN CONTRACT: terraform local-exec provisioners in the consumer
         # repos run bare `tsh ssh ...` and rely on this ambient session.
         run: |
-          echo "TELEPORT_IDENTITY_FILE=${{ steps.teleport-auth.outputs.identity-file }}" >> "$GITHUB_ENV"
-          echo "TBOT_DEST_DIR=${{ steps.teleport-auth.outputs.destination-dir }}" >> "$GITHUB_ENV"
+          echo "TELEPORT_IDENTITY_FILE=${{ steps.teleport-auth.outputs.identity-file || steps.teleport-auth-retry.outputs.identity-file }}" >> "$GITHUB_ENV"
+          echo "TBOT_DEST_DIR=${{ steps.teleport-auth.outputs.destination-dir || steps.teleport-auth-retry.outputs.destination-dir }}" >> "$GITHUB_ENV"
           echo "TELEPORT_PROXY=${TELEPORT_FQDN}" >> "$GITHUB_ENV"
 
       # --- Vault: tunnel mode (mssql/ad omicron) ---------------------------


### PR DESCRIPTION
## Why

`teleport-actions/auth` mints the SSH certificate by running tbot, and tbot's heartbeat to the proxy fails often enough to be a nuisance:

```
ERRO [TBOT] Service exited with error service:heartbeat error:[
  Original Error: *interceptors.RemoteError keepalive ping failed to receive ACK within timeout
##[error]Error: The process '/opt/hostedtoolcache/teleport/18.10.0-linux-amd64/x64/tbot' failed with exit code 1
```

It kills the job at the auth step — before a single ansible task, terraform plan or host is touched — so the run goes red for reasons that have nothing to do with the change under test. Hit again today on maestra-io/maestra-nat-gateway#207 (the omega check job), where a plain re-run went green with no code change.

## What

One retry on the auth step in all three workflows that authenticate this way (`ansible-run`, `terraform-run`, `ansible-os-update`). GitHub has no native retry for `uses:` steps, so this is the standard shape: the first attempt carries `continue-on-error`, the retry runs `if: steps.teleport-auth.outcome == 'failure'` and is the one that decides the job.

The subtle part is the identity. Downstream steps consume `steps.teleport-auth.outputs.identity-file` / `destination-dir`, and a retry step has its own id — so if the retry is the attempt that succeeds, those references would silently resolve to empty and SSH auth would fail later, in a much more confusing place. Every reference site now reads across both attempts:

```yaml
TELEPORT_IDENTITY_FILE: ${{ steps.teleport-auth.outputs.identity-file || steps.teleport-auth-retry.outputs.identity-file }}
```

I enumerated the consumers rather than trusting a grep of one file — 3 workflows, 7 reference sites (ansible-run ×3, terraform-run ×2, ansible-os-update ×2), zero bare references left:

```
$ grep -rn "steps.teleport-auth.outputs" .github/workflows/*.yml | grep -v "teleport-auth-retry.outputs" | wc -l
0
```

No interface change for the seven consumer repos — this is internal to the reusable workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)