### PR TITLE
fix(os_update): a failure inside always must not skip the rest of the cleanup

### DIFF
--- a/ansible/collections/maestra/infra/roles/os_update/tasks/guards.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/guards.yml
@@ -28,6 +28,16 @@
   when: (os_update_am_url | default('')) | length > 0
 
 - name: Which other hosts hold an open os-update drain window
+  # The self-exclusion pattern is the PLAIN string `host=<me> ` with a trailing space —
+  # not `host=<me>(\s|$)`. This is YAML: inside a folded scalar a backslash is literal,
+  # so `(\\s|$)` reached the regex engine as an escaped backslash and never matched.
+  # The host's own silence then counted as "somebody else is draining", and the guard
+  # blocked a re-run of the very host that had left the silence behind
+  # (us-omicron-lw-haproxy-cdp-01, run 29368611005).
+  #
+  # The comment always continues with ` run=...` after the hostname, so the trailing
+  # space is an exact, escape-free discriminator — and it still tells `...-cdp-01`
+  # apart from a hypothetical `...-cdp-011`.
   ansible.builtin.set_fact:
     os_update_other_drains: >-
       {{ os_update_silences.json
@@ -35,7 +45,7 @@
          | selectattr('status.state', 'equalto', 'active')
          | selectattr('createdBy', 'defined')
          | selectattr('createdBy', 'search', '^gha-os-update')
-         | rejectattr('comment', 'search', 'host=' ~ inventory_hostname ~ '(\\s|$)')
+         | rejectattr('comment', 'search', 'host=' ~ inventory_hostname ~ ' ')
          | map(attribute='comment')
          | list }}
   when: (os_update_am_url | default('')) | length > 0

--- a/ansible/collections/maestra/infra/roles/os_update/tasks/main.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/main.yml
@@ -118,30 +118,77 @@
           FAILED on {{ inventory_hostname }} — un-draining this host, then aborting
           the fleet (the GH matrix is fail-fast, no further host is touched).
 
+  # EVERY step here is individually rescued. A bare list of tasks in `always` is a
+  # trap: the first one that fails ABORTS the rest of the block, so a single bad
+  # probe inside the undrain silently skips the marker clear and the unsilence — and
+  # the host ends up flagged as stranded (and silenced) while it is actually fine.
+  # That is exactly what happened to us-omicron-lw-haproxy-cdp-01 (run 29367636656):
+  # undrain's `wait_for 127.0.0.1:443` timed out (that farm binds its real IPs, not
+  # loopback) AFTER haproxy had already been started, the rest of `always` never ran,
+  # and the leftover marker + silence then blocked the NEXT run on the
+  # one-host-at-a-time guard.
   always:
     - name: Restore the pre-existing hold set
-      ansible.builtin.include_tasks: holds.yml
-      vars:
-        os_update_holds_action: restore
+      block:
+        - name: Restore holds
+          ansible.builtin.include_tasks: holds.yml
+          vars:
+            os_update_holds_action: restore
+      rescue:
+        - name: Hold restore failed — carry on with the rest of the cleanup
+          ansible.builtin.debug:
+            msg: >-
+              WARNING: could not restore the pre-existing apt holds on {{ inventory_hostname }}.
+              Check `apt-mark showhold` by hand. Continuing with the undrain.
 
     - name: UNDRAIN — put the host back into rotation (idempotent)
-      ansible.builtin.include_tasks: "{{ os_update_hooks_dir }}/undrain.yml"
+      block:
+        - name: Undrain
+          ansible.builtin.include_tasks: "{{ os_update_hooks_dir }}/undrain.yml"
+      rescue:
+        - name: The undrain itself failed — the host may still be OUT of rotation
+          ansible.builtin.set_fact:
+            os_update_undrain_failed: true
 
+        - name: Say so loudly
+          ansible.builtin.debug:
+            msg: >-
+              UNDRAIN FAILED on {{ inventory_hostname }} — it may still be out of rotation.
+              The drain marker is deliberately LEFT IN PLACE so OsUpdateHostStrandedDrain
+              fires and a human finishes the job:
+              gh workflow run os-update.yml -f mode=undrain-only -f host_limit={{ inventory_hostname }}
+
+    # Only when the undrain actually succeeded. If it did not, the marker MUST stay:
+    # it is the one signal that says "this host is still out of rotation".
     - name: Clear the drain marker
       ansible.builtin.include_tasks: marker.yml
       vars:
         os_update_marker_action: clear
+      when: not (os_update_undrain_failed | default(false))
 
     - name: SETTLE — traffic is actually flowing again and the pair is redundant
       ansible.builtin.include_tasks: "{{ os_update_hooks_dir }}/settle.yml"
-      when: not (os_update_failed | default(false))
+      when:
+        - not (os_update_failed | default(false))
+        - not (os_update_undrain_failed | default(false))
 
+    # Always dropped, even on a failed undrain: the silences are time-boxed anyway,
+    # and a stranded host is precisely the case where we want the alerts to fire.
     - name: Drop the silences
-      ansible.builtin.include_tasks: unsilence.yml
+      block:
+        - name: Unsilence
+          ansible.builtin.include_tasks: unsilence.yml
+      rescue:
+        - name: Could not expire the silences — the dead-man endsAt still covers us
+          ansible.builtin.debug:
+            msg: "WARNING: could not expire the maintenance silences; they expire on their own in <= {{ os_update_silence_minutes }} min."
 
-    - name: Fail the job (after the host was returned to rotation)
+    - name: Fail the job
       ansible.builtin.fail:
         msg: >-
-          OS update FAILED on {{ inventory_hostname }}. The host was un-drained
-          (or the undrain itself failed — read above). No further host is touched.
-      when: os_update_failed | default(false)
+          OS update FAILED on {{ inventory_hostname }}.
+          {{ 'The host was un-drained and is back in rotation.'
+             if not (os_update_undrain_failed | default(false))
+             else 'THE UNDRAIN ALSO FAILED — the host may still be OUT of rotation, and the drain marker was left in place on purpose.' }}
+          No further host is touched (the matrix is fail-fast).
+      when: (os_update_failed | default(false)) or (os_update_undrain_failed | default(false))


### PR DESCRIPTION
fix(os_update): a failure inside `always` must not skip the rest of the cleanup

This is the bug that actually strands a host, and it bit for real.

us-omicron-lw-haproxy-cdp-01 (run 29367636656): the run failed in verify, the rescue
path fired, and `always` began the cleanup — restore holds, undrain, clear marker,
unsilence. The undrain STARTED haproxy successfully and then failed on its own probe
(`wait_for 127.0.0.1:443`; that farm binds its real IPs with `transparent` and never
listens on loopback — fixed separately in haproxy-maestra#279).

A bare list of tasks in `always` is a trap: the first failure ABORTS the block. So the
marker was never cleared and the maintenance silence never expired — on a host that
was, at that moment, serving traffic perfectly well. Consequences, in order:

  * OsUpdateHostStrandedDrain paged on a healthy host (Rootly #88dQXe);
  * the leftover silence then made the one-host-at-a-time guard reject the NEXT run of
    that same host — "another os-update drain window is open" — pointing at the host's
    OWN silence (run 29368611005).

Two fixes here:

1. Every step of `always` is individually rescued, so one bad probe can no longer
   swallow the cleanup behind it. The semantics are kept honest: if the UNDRAIN itself
   fails, the marker is deliberately LEFT in place (it is the only signal saying "this
   host is still out of rotation") and the job fails loudly with the undrain-only
   escape hatch in the message. The silences are dropped either way — they are
   time-boxed, and a stranded host is exactly when the alerts should fire.

2. guards.yml no longer fails to recognise the host's OWN silence. The self-exclusion
   pattern was `host=<me>(\s|$)` inside a YAML folded scalar, where a backslash is
   literal — so the regex engine received an escaped backslash and never matched. It
   is now the plain string `host=<me> ` with a trailing space, which is exact (the
   comment always continues with ` run=...`), escape-free, and still tells `-cdp-01`
   apart from `-cdp-011`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
