### PR TITLE
fix(ansible-pr): strip profile_tasks noise from the plan-diff comment

### DIFF
--- a/.github/workflows/ansible-pr.yml
+++ b/.github/workflows/ansible-pr.yml
@@ -203,11 +203,14 @@ jobs:
             // and got cut off. Strip the banners, chop everything from
             // TASKS RECAP down (PLAY RECAP sits above it and survives), and
             // only then take the tail.
+            // Banner match keys on the invariant tail "(elapsed)  cumulative ***"
+            // rather than the leading timestamp, whose format is configurable
+            // (datetime_format=iso8601 or custom strftime).
             const stripProfileNoise = (s) => s
               .split('\n')
-              .filter(l => !/^\w+ \d{1,2} \w+ \d{4}\s+\d{2}:\d{2}:\d{2} [+-]\d{4}\s+\(\d+:\d{2}:\d{2}\.\d+\)\s+\d+:\d{2}:\d{2}\.\d+ \*+\s*$/.test(l))
+              .filter(l => !/^.{0,80}\(\d+:\d{2}:\d{2}\.\d+\)\s+\d+:\d{2}:\d{2}\.\d+ \*+\s*$/.test(l))
               .join('\n')
-              .replace(/\n+TASKS RECAP \*+[\s\S]*$/, '\n')
+              .replace(/(?:^|\n)[\n]*TASKS RECAP \*+[\s\S]*$/, '\n')
               .replace(/\n{3,}/g, '\n\n');
 
             let files = [];

--- a/.github/workflows/ansible-pr.yml
+++ b/.github/workflows/ansible-pr.yml
@@ -196,6 +196,20 @@ jobs:
             const stripAnsi = (s) => s.replace(/\x1b\[[0-9;]*m/g, '');
             const count = (s, re) => { const m = s.match(re); return m ? m.length : 0; };
 
+            // The profile_tasks callback pollutes plan logs with a per-task
+            // timestamp banner line and a giant end-of-run timing summary
+            // (TASKS RECAP / PLAYBOOK RECAP). A blind tail() of the raw log
+            // showed ONLY that noise — the actual --diff output sits above it
+            // and got cut off. Strip the banners, chop everything from
+            // TASKS RECAP down (PLAY RECAP sits above it and survives), and
+            // only then take the tail.
+            const stripProfileNoise = (s) => s
+              .split('\n')
+              .filter(l => !/^\w+ \d{1,2} \w+ \d{4}\s+\d{2}:\d{2}:\d{2} [+-]\d{4}\s+\(\d+:\d{2}:\d{2}\.\d+\)\s+\d+:\d{2}:\d{2}\.\d+ \*+\s*$/.test(l))
+              .join('\n')
+              .replace(/\n+TASKS RECAP \*+[\s\S]*$/, '\n')
+              .replace(/\n{3,}/g, '\n\n');
+
             let files = [];
             try {
               files = fs.readdirSync(logsDir)
@@ -225,9 +239,10 @@ jobs:
               const hasChanges = changed > 0;
               const hasFailed = failed > 0 || unreach > 0;
               if (hasChanges || hasFailed) {
-                const body = raw.length > MAX_PER_ENV
-                  ? raw.slice(-MAX_PER_ENV) + '\n... (truncated)'
-                  : raw;
+                const clean = stripProfileNoise(raw);
+                const body = clean.length > MAX_PER_ENV
+                  ? '... (older output truncated)\n' + clean.slice(-MAX_PER_ENV)
+                  : clean;
                 sections.push(`<details><summary>${env} — ${status}</summary>\n\n\`\`\`\n${body}\n\`\`\`\n</details>`);
               }
             }


### PR DESCRIPTION
## Problem

The per-env `<details>` section in the plan-diff PR comment takes a blind `tail(comment_max_chars)` of the raw plan log. With the `profile_tasks` callback enabled (mssql-maestra), the tail is entirely per-task timestamp banners plus the end-of-run `TASKS RECAP` / `PLAYBOOK RECAP` timing summary — the actual `--diff` output sits above it and gets cut off. Result: recap says `changed=N` but the comment body shows zero actual changes (see maestra-io/mssql-maestra#30 comment).

## Fix

Before taking the tail:
- strip `profile_tasks` per-task timestamp banner lines
- chop everything from `TASKS RECAP` down (`PLAY RECAP` sits above it and survives)
- collapse blank-line runs

Verified against the real `plan-us-omega-lw_sql.log` artifact from mssql run 29336360089: raw 19.4KB → clean 5.0KB, tail now shows the changed TASK blocks + PLAY RECAP instead of timing noise. No-op for repos that don't enable `profile_tasks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMbTFX55LW2xfXpkSsNiJy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates Ansible PR comment generation to remove `profile_tasks` noise before truncating logs. It now strips task timing banners, excludes `TASKS RECAP`, collapses blank lines, and preserves meaningful `--diff` and `PLAY RECAP` output in environment details.

No breaking changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->