### PR TITLE
feat: runs_on input — run on self-hosted ARC scale sets

### DIFF
--- a/.github/workflows/ansible-pr.yml
+++ b/.github/workflows/ansible-pr.yml
@@ -78,6 +78,11 @@ on:
         required: false
         type: string
         default: ""
+      runs_on:
+        description: "Runner label for the check-matrix jobs (forwarded to ansible-run). Lint and the comment job stay on ubuntu-latest."
+        required: false
+        type: string
+        default: "ubuntu-latest"
       extra_run_args:
         description: "Extra ansible-playbook args (workflow-wide default; per-row extra_run_args in `envs` wins)"
         required: false
@@ -170,6 +175,7 @@ jobs:
       requirements_pip: ${{ inputs.requirements_pip }}
       requirements_galaxy: ${{ inputs.requirements_galaxy }}
       python_version: ${{ inputs.python_version }}
+      runs_on: ${{ inputs.runs_on }}
       artifact_name: ansible-check-${{ matrix.env.region }}-${{ matrix.env.environment }}-${{ matrix.env.site }}${{ matrix.env.inventory_group_suffix || '' }}
 
   comment:

--- a/.github/workflows/ansible-run.yml
+++ b/.github/workflows/ansible-run.yml
@@ -140,6 +140,17 @@ on:
         type: boolean
         default: false
       # --- misc ----------------------------------------------------------
+      runs_on:
+        description: >-
+          Runner label for the job. Default is GitHub-hosted ubuntu-latest;
+          pass a self-hosted ARC scale-set name (e.g. us-omicron-lw-runners)
+          to run in-cluster. The ARC runner image is minimal but carries
+          everything this workflow needs (jq/curl/git/python3/docker); note
+          sudo is blocked there (no-new-privileges), so steps must not
+          install system packages.
+        required: false
+        type: string
+        default: "ubuntu-latest"
       extra_env:
         description: "Extra KEY=VALUE lines injected into the Execute step env (may reference secrets already exported to \\$GITHUB_ENV)."
         required: false
@@ -201,7 +212,7 @@ permissions:
 
 jobs:
   ansible:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs_on }}
     environment: ${{ inputs.gh_environment }}
     concurrency:
       # Two classes, deliberately NOT one group.


### PR DESCRIPTION
Adds `runs_on` (default `ubuntu-latest`) to the `ansible-run` reusable and a passthrough on `ansible-pr`'s check matrix, so consumers can target the in-cluster ARC runners (`us-omicron-lw-runners`, unblocked today — GitHub App creds landed in the omicron in-cluster vault, listener Running, smoke test maestra-io/mssql-maestra#39 green: jq/curl/git/python3/docker present, Teleport proxy reachable).

Lint + PR-comment jobs stay GitHub-hosted. No behavior change for existing callers (default preserved).

First consumer: mssql-maestra PR checks (follow-up PR pins this SHA and sets `runs_on: us-omicron-lw-runners` — its own check run is the live validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMbTFX55LW2xfXpkSsNiJy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added configurable `runs_on` inputs to the reusable `ansible-pr` and `ansible-run` workflows.
- Defaults to `ubuntu-latest`, preserving existing behavior.
- Passes the selected runner to check jobs while keeping lint and PR-comment jobs on GitHub-hosted runners.

## Breaking Changes

None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->