### PR TITLE
feat(ansible-pr): per-row runs_on in the check matrix

### DIFF
--- a/.github/workflows/ansible-pr.yml
+++ b/.github/workflows/ansible-pr.yml
@@ -79,7 +79,7 @@ on:
         type: string
         default: ""
       runs_on:
-        description: "Runner label for the check-matrix jobs (forwarded to ansible-run). Lint and the comment job stay on ubuntu-latest."
+        description: "Default runner label for the check-matrix jobs; a per-row runs_on in `envs` wins. Rows target different environments whose runners must not cross (omicron rows -> us-omicron-lw-runners; omega rows -> omega's own set). Lint and the comment job stay on ubuntu-latest."
         required: false
         type: string
         default: "ubuntu-latest"
@@ -175,7 +175,7 @@ jobs:
       requirements_pip: ${{ inputs.requirements_pip }}
       requirements_galaxy: ${{ inputs.requirements_galaxy }}
       python_version: ${{ inputs.python_version }}
-      runs_on: ${{ inputs.runs_on }}
+      runs_on: ${{ matrix.env.runs_on || inputs.runs_on }}
       artifact_name: ansible-check-${{ matrix.env.region }}-${{ matrix.env.environment }}-${{ matrix.env.site }}${{ matrix.env.inventory_group_suffix || '' }}
 
   comment:


### PR DESCRIPTION
Environments' runners must not cross (an omicron in-cluster runner must never execute an omega play). A per-row `runs_on` in `envs` now wins over the workflow-wide input; default (`ubuntu-latest`) unchanged — no behavior change for existing callers.

First use: mssql-maestra restores its omicron check row with `"runs_on": "us-omicron-lw-runners"` while omega rows stay GitHub-hosted (ARC reliability A/B test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMbTFX55LW2xfXpkSsNiJy