### PR TITLE
fix(os-update): unbrick undrain-only, close silence gaps, honest gates

### DIFF
--- a/.github/workflows/ansible-os-update.yml
+++ b/.github/workflows/ansible-os-update.yml
@@ -62,8 +62,9 @@ on:
         default: "plan"
       order:
         description: >-
-          Explicit host order, CSV. Empty = alphabetical. Every name must exist in the
-          target group (a typo fails the run rather than silently skipping a host).
+          Explicit host order, CSV. Empty = alphabetical. Must list EVERY host in the
+          target group exactly once (a typo, a duplicate or an omitted host fails the
+          run rather than silently skipping a host); use host_limit for a single host.
         required: false
         type: string
         default: ""
@@ -189,21 +190,39 @@ jobs:
           HOST_LIMIT: ${{ inputs.host_limit }}
           ORDER: ${{ inputs.order }}
           MAX_HOSTS: ${{ inputs.max_hosts }}
+          MODE: ${{ inputs.mode }}
         run: |
           set -euo pipefail
+
+          # The reusable contract is open to any caller (the shims use type: choice,
+          # but nothing forces a caller to). An unknown mode would make the apply
+          # job's `if` false and the run would end GREEN as a plan — a typo'd
+          # `mode=aply` must fail loudly instead.
+          case "${MODE}" in
+            plan|apply|undrain-only) ;;
+            *) echo "::error::Unknown mode '${MODE}' — must be plan, apply or undrain-only"; exit 1;;
+          esac
+
           ansible-inventory -i "${{ inputs.inventory }}" --list > /tmp/inv.json
 
           if [ -n "${HOST_LIMIT}" ]; then
             HOSTS="$(jq -cn --arg h "${HOST_LIMIT}" '[$h]')"
           elif [ -n "${ORDER}" ]; then
-            # Explicit order. Every named host must be in the group — a typo must fail
-            # the run, not silently drop a host from the fleet sweep.
+            # Explicit order. The list must be exactly the group: a typo must fail the
+            # run, a duplicate must not produce two matrix legs for one host, and an
+            # OMITTED host must not be silently dropped from the fleet sweep.
             HOSTS="$(jq -c --arg g "${GROUP}" --arg o "${ORDER}" '
               ($o | split(",") | map(gsub("^\\s+|\\s+$";""))) as $want
               | (.[$g].hosts // []) as $have
               | ($want - $have) as $bogus
+              | ($want | group_by(.) | map(select(length > 1) | .[0])) as $dupes
+              | ($have - $want) as $missing
               | if ($bogus | length) > 0
                 then error("hosts not in group \($g): \($bogus | join(", "))")
+                elif ($dupes | length) > 0
+                then error("duplicate hosts in order: \($dupes | join(", "))")
+                elif ($missing | length) > 0
+                then error("order must list every host in group \($g) — missing: \($missing | join(", ")). Use host_limit for a single host.")
                 else $want end' /tmp/inv.json)"
           else
             HOSTS="$(jq -c --arg g "${GROUP}" '(.[$g].hosts // []) | sort' /tmp/inv.json)"
@@ -239,6 +258,12 @@ jobs:
   # 29360255290).
   plan:
     needs: enumerate
+    # NOT in undrain-only: the plan runs the role in os_update_mode=plan, which
+    # includes the consumer preflight — and on a host stranded mid-drain (haproxy
+    # soft-stopped + masked) that preflight FAILS, which would skip `apply` and
+    # brick the very escape hatch undrain-only exists to be. The hatch skips the
+    # plan on purpose, exactly like the role skips preflight on purpose.
+    if: ${{ inputs.mode != 'undrain-only' }}
     uses: ./.github/workflows/ansible-run.yml
     secrets: inherit
     with:
@@ -271,11 +296,20 @@ jobs:
         -e os_update_am_url=http://127.0.0.1:9093
         -e os_update_allow_multi=true
         ${{ inputs.extra_run_args }}
-      artifact_name: os-update-plan-${{ inputs.region }}-${{ inputs.environment }}-${{ inputs.site }}${{ inputs.inventory_group_suffix }}-${{ github.run_number }}
+      # run_attempt: upload-artifact v4 rejects a duplicate name within a run (409),
+      # and "Re-run failed jobs" — the documented resume button — reuses run_number.
+      artifact_name: os-update-plan-${{ inputs.region }}-${{ inputs.environment }}-${{ inputs.site }}${{ inputs.inventory_group_suffix }}-${{ github.run_number }}-${{ github.run_attempt }}
 
   apply:
     needs: [enumerate, plan]
-    if: ${{ inputs.mode == 'apply' || inputs.mode == 'undrain-only' }}
+    # `!cancelled()` because in undrain-only the plan job is SKIPPED (see above) and
+    # the default `success()` would skip this job too. plan success is still required
+    # for mode=apply; undrain-only needs only the host list.
+    if: >-
+      ${{ !cancelled()
+          && needs.enumerate.result == 'success'
+          && (needs.plan.result == 'success' || inputs.mode == 'undrain-only')
+          && (inputs.mode == 'apply' || inputs.mode == 'undrain-only') }}
     strategy:
       matrix:
         host: ${{ fromJSON(needs.enumerate.outputs.hosts) }}
@@ -306,7 +340,11 @@ jobs:
         -e os_update_post_reboot_delay=${{ inputs.post_reboot_delay }}
         -e os_update_run_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         ${{ inputs.extra_run_args }}
-      artifact_name: os-update-${{ matrix.host }}-${{ github.run_number }}
+      # run_attempt: the failed attempt already uploaded os-update-<host>-<N> (the
+      # upload step is if: always()), and upload-artifact v4 409s on a duplicate
+      # name — without the attempt suffix, "Re-run failed jobs" red-loops on the
+      # artifact step after the playbook has already succeeded.
+      artifact_name: os-update-${{ matrix.host }}-${{ github.run_number }}-${{ github.run_attempt }}
       # The family rule (ansible-manual.yml): omega is gated by a GitHub Environment,
       # omicron is not. Never invent an environment name for omicron — GitHub would
       # silently create it WITHOUT protection rules, which reads like a gate and isn't one.
@@ -322,7 +360,11 @@ jobs:
   # this fleet on the SOC board in the first place are actually gone.
   soc-rescan:
     needs: [enumerate, apply]
-    if: ${{ inputs.mode == 'apply' && needs.apply.result == 'success' }}
+    # Also on apply FAILURE: a partial sweep (host k fails, fail-fast cancels the
+    # rest) has still patched hosts 1..k-1, and skipping the re-scan would leave
+    # exactly the stale-board scenario this job exists to prevent. The dispatched
+    # list is the full enumerate list — re-scanning an unpatched host is harmless.
+    if: ${{ inputs.mode == 'apply' && !cancelled() && contains(fromJSON('["success","failure"]'), needs.apply.result) }}
     runs-on: ubuntu-latest
     steps:
       # A dedicated GitHub App (org variable SOC_DISPATCH_APP_ID + org secret
@@ -350,6 +392,7 @@ jobs:
         env:
           HOSTS: ${{ needs.enumerate.outputs.hosts }}
           SOC_TOKEN: ${{ steps.soc-token.outputs.token }}
+          SOC_TOKEN_OUTCOME: ${{ steps.soc-token.outcome }}
         run: |
           set -euo pipefail
           LIST="$(printf '%s' "${HOSTS}" | jq -r 'join(",")')"
@@ -358,6 +401,26 @@ jobs:
             # Loud, never silently green. A skipped re-scan means SOC keeps showing the
             # PRE-PATCH findings, and the next person to look at the board concludes the
             # fleet is still vulnerable — or, worse, that the patch run did nothing.
+            # Two distinct causes, two distinct remediations: the App may be absent
+            # (outcome=skipped — the mint step never ran), or configured but BROKEN
+            # (outcome=failure — revoked installation, bad private key; the
+            # continue-on-error swallowed it).
+            if [ "${SOC_TOKEN_OUTCOME}" = "failure" ]; then
+              echo "::warning::SOC re-scan SKIPPED — the dispatch App IS configured (org var SOC_DISPATCH_APP_ID) but the token mint FAILED — check the App installation on maestra-io/soc and the SOC_DISPATCH_APP_PRIVATE_KEY secret. The hosts ARE patched, but the SOC board still shows pre-patch findings until someone runs: gh workflow run vuln-scan.yaml --repo maestra-io/soc -f hosts=${LIST}"
+              {
+                echo "### SOC re-scan SKIPPED — App configured but token mint FAILED"
+                echo ""
+                echo "The hosts **are** patched, but the SOC board still shows the pre-patch"
+                echo "findings until it is re-scanned. Run it by hand:"
+                echo ""
+                echo "    gh workflow run vuln-scan.yaml --repo maestra-io/soc -f hosts=${LIST}"
+                echo ""
+                echo "Then fix the dispatch App: check the App installation on \`maestra-io/soc\`"
+                echo "and that the org secret \`SOC_DISPATCH_APP_PRIVATE_KEY\` matches the App in"
+                echo "the org variable \`SOC_DISPATCH_APP_ID\` (see the failed mint step's log)."
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
             echo "::warning::SOC re-scan SKIPPED — the SOC dispatch App is not configured (org var SOC_DISPATCH_APP_ID / secret SOC_DISPATCH_APP_PRIVATE_KEY). The hosts ARE patched, but the SOC board still shows pre-patch findings until someone runs: gh workflow run vuln-scan.yaml --repo maestra-io/soc -f hosts=${LIST}"
             {
               echo "### SOC re-scan SKIPPED — dispatch App not configured"

--- a/ansible/collections/maestra/infra/roles/os_update/tasks/holds.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/holds.yml
@@ -65,11 +65,34 @@
 - name: Restore the pre-existing hold set
   when: os_update_holds_action == 'restore'
   block:
+    # No `failed_when: false` here: it would make the hold-restore rescue in
+    # main.yml dead code — a swallowed unhold failure (dpkg lock right after apt
+    # activity, full disk) leaves teleport/frr/consul held FOREVER, and their own
+    # IaC-driven upgrades then fail silently on the next run.
     - name: Unhold only what WE held (someone else's pins stay put)
       ansible.builtin.command:
         argv: "{{ ['apt-mark', 'unhold'] + os_update_our_holds }}"
       register: os_update_unhold_cmd
       changed_when: "'canceled' in os_update_unhold_cmd.stdout"
       check_mode: false
-      failed_when: false
+      when: (os_update_our_holds | default([]) | length) > 0
+
+    - name: Re-read the holds (apt-mark can exit 0 without actually unholding)
+      ansible.builtin.command:
+        argv: [apt-mark, showhold]
+      register: os_update_showhold_after
+      changed_when: false
+      check_mode: false
+      when: (os_update_our_holds | default([]) | length) > 0
+
+    - name: Assert none of OUR holds survived the unhold
+      ansible.builtin.assert:
+        that:
+          - >-
+            (os_update_our_holds | intersect(os_update_showhold_after.stdout_lines | default([]))) | length == 0
+        fail_msg: >-
+          Holds we set are still in place after unhold:
+          {{ os_update_our_holds | intersect(os_update_showhold_after.stdout_lines | default([])) }}.
+          Left held, their IaC-driven upgrades (`apt-get install teleport=X`) fail
+          silently. Clean up with `apt-mark unhold` by hand.
       when: (os_update_our_holds | default([]) | length) > 0

--- a/ansible/collections/maestra/infra/roles/os_update/tasks/kernel_gc.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/kernel_gc.yml
@@ -23,8 +23,23 @@
     - os_update_rebooted | default(false)
     - (os_update_boot_free_post.stdout | trim | int) < (os_update_boot_free_gc_threshold_mb | int)
 
+# Re-probe when the GC actually ran — os_update_boot_free_post was measured
+# BEFORE the purge, and the one case this message matters is the one where the
+# number just changed.
+- name: Re-measure /boot after the GC
+  ansible.builtin.shell:
+    executable: /bin/bash
+    cmd: |
+      set -o pipefail
+      df -Pm /boot | awk 'NR==2 {print $4}'
+  register: os_update_boot_free_final
+  changed_when: false
+  check_mode: false
+  when: os_update_gc.changed | default(false)
+
 - name: /boot after GC
   ansible.builtin.debug:
     msg: >-
-      {{ inventory_hostname }}: /boot free {{ os_update_boot_free_post.stdout | trim }} MB
+      {{ inventory_hostname }}: /boot free
+      {{ (os_update_boot_free_final.stdout | default(os_update_boot_free_post.stdout)) | trim }} MB
       {{ '(GC ran)' if (os_update_gc.changed | default(false)) else '(GC not needed)' }}

--- a/ansible/collections/maestra/infra/roles/os_update/tasks/main.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/main.yml
@@ -159,18 +159,45 @@
               gh workflow run os-update.yml -f mode=undrain-only -f host_limit={{ inventory_hostname }}
 
     # Only when the undrain actually succeeded. If it did not, the marker MUST stay:
-    # it is the one signal that says "this host is still out of rotation".
+    # it is the one signal that says "this host is still out of rotation" — it is
+    # what makes OsUpdateHostStrandedDrain fire and mode=undrain-only meaningful.
     - name: Clear the drain marker
-      ansible.builtin.include_tasks: marker.yml
-      vars:
-        os_update_marker_action: clear
       when: not (os_update_undrain_failed | default(false))
+      block:
+        - name: Clear the marker
+          ansible.builtin.include_tasks: marker.yml
+          vars:
+            os_update_marker_action: clear
+      rescue:
+        - name: Marker clear failed — the rest of the cleanup must still run
+          ansible.builtin.set_fact:
+            os_update_failed: true
+
+        - name: Say so
+          ansible.builtin.debug:
+            msg: >-
+              WARNING: could not clear the drain marker on {{ inventory_hostname }} —
+              OsUpdateHostStrandedDrain may fire on a host that IS back in rotation.
+              Continuing so the silences are still dropped and the job fails.
 
     - name: SETTLE — traffic is actually flowing again and the pair is redundant
-      ansible.builtin.include_tasks: "{{ os_update_hooks_dir }}/settle.yml"
       when:
         - not (os_update_failed | default(false))
         - not (os_update_undrain_failed | default(false))
+      block:
+        - name: Settle
+          ansible.builtin.include_tasks: "{{ os_update_hooks_dir }}/settle.yml"
+      rescue:
+        - name: Settle failed — the host is back in rotation but UNPROVEN
+          ansible.builtin.set_fact:
+            os_update_failed: true
+
+        - name: Say so
+          ansible.builtin.debug:
+            msg: >-
+              WARNING: settle failed on {{ inventory_hostname }} — the host is back in
+              rotation but not proven to be serving. Continuing so the silences are
+              dropped (the alerts must be free to fire on it) and the job fails.
 
     # Always dropped, even on a failed undrain: the silences are time-boxed anyway,
     # and a stranded host is precisely the case where we want the alerts to fire.

--- a/ansible/collections/maestra/infra/roles/os_update/tasks/plan.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/plan.yml
@@ -73,7 +73,16 @@
     os_update_holds_before: "{{ os_update_holds_cmd.stdout_lines | default([]) }}"
     os_update_newest_kernel: "{{ os_update_newest_kernel_cmd.stdout | trim }}"
     os_update_boot_free_mb: "{{ os_update_boot_free_cmd.stdout | trim | int }}"
-    os_update_needed: "{{ (os_update_pending | length) > 0 }}"
+    # Pending MINUS pinned: the pinned packages are held before the real upgrade,
+    # so a host whose ONLY pending updates are pinned ones (teleport releases
+    # near-weekly, and teleport is pinned everywhere) is a guaranteed no-op —
+    # draining and reboot-checking the whole fleet for it would contradict the
+    # "already up to date = ~60 s, never drained" contract. Same `( |$)`-anchored
+    # pattern as the holds tripwire; os_update_pending stays raw for the report.
+    os_update_needed: >-
+      {{ (os_update_pending
+          | reject('match', '^Inst (' ~ ((os_update_pinned_base + os_update_pinned_extra) | unique | join('|')) ~ ')( |$)')
+          | list | length) > 0 }}
     # Two INDEPENDENT conditions, both first-class:
     #   - the package manager asked for a reboot, OR
     #   - a newer kernel is installed than the one we booted, OR

--- a/ansible/collections/maestra/infra/roles/os_update/tasks/silence.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/silence.yml
@@ -14,6 +14,14 @@
     that: (os_update_silence_minutes | int) < 30
     fail_msg: "os_update_silence_minutes must stay below OsUpdateHostStrandedDrain's for: (30m)."
 
+# Timestamps: a FRESH epoch (never ansible_facts.date_time.epoch — that one is
+# frozen at fact-gathering, and guards+plan+preflight have been eating into the
+# dead-man window for minutes by the time we get here), formatted with utc=true
+# (strftime without it renders the CONTROLLER'S local timezone and the literal
+# `Z` turns it into a lie: west of UTC the silence is created `pending` and the
+# drain proceeds unsilenced; east of UTC the endsAt can land in the past).
+# `now().timestamp()` is the local wall clock, which Python converts to the
+# correct Unix epoch regardless of the controller's TZ.
 - name: Create the maintenance silences
   ansible.builtin.uri:
     url: "{{ os_update_am_url }}/api/v2/silences"
@@ -21,8 +29,8 @@
     body_format: json
     body:
       matchers: "{{ item }}"
-      startsAt: "{{ '%Y-%m-%dT%H:%M:%S.000Z' | strftime(ansible_facts.date_time.epoch | int) }}"
-      endsAt: "{{ '%Y-%m-%dT%H:%M:%S.000Z' | strftime((ansible_facts.date_time.epoch | int) + (os_update_silence_minutes | int) * 60) }}"
+      startsAt: "{{ '%Y-%m-%dT%H:%M:%S.000Z' | strftime(now().timestamp(), utc=true) }}"
+      endsAt: "{{ '%Y-%m-%dT%H:%M:%S.000Z' | strftime(now().timestamp() + (os_update_silence_minutes | int) * 60, utc=true) }}"
       createdBy: "gha-os-update"
       comment: "OS update issues-maestra#1104 host={{ inventory_hostname }} run={{ os_update_run_url }}"
     status_code: 200
@@ -35,3 +43,54 @@
 - name: Remember the silence IDs so `always` can drop them
   ansible.builtin.set_fact:
     os_update_silence_ids: "{{ os_update_silence_post.results | map(attribute='json.silenceID') | list }}"
+
+# The one-at-a-time guard ran at play start; minutes of plan+preflight have
+# passed since, and nothing serializes sweeps ACROSS the three consumer repos
+# sharing a contour (GH max-parallel:1 only serializes within one workflow).
+# Close the TOCTOU: now that OUR silence is up, re-fetch and assert we are the
+# ONLY holder — the loser of the race expires its own silences and aborts
+# BEFORE anything is drained.
+- name: Re-fetch the silences — did anyone else start draining since the guard ran
+  ansible.builtin.uri:
+    url: "{{ os_update_am_url }}/api/v2/silences"
+    return_content: true
+    status_code: 200
+  delegate_to: localhost
+  become: false
+  check_mode: false
+  register: os_update_silences_recheck
+
+- name: Which OTHER hosts hold an open os-update drain window now
+  # Same discriminator as guards.yml: plain string `host=<me> ` with the trailing
+  # space (the comment always continues with ` run=`).
+  ansible.builtin.set_fact:
+    os_update_silence_contenders: >-
+      {{ os_update_silences_recheck.json
+         | default([])
+         | selectattr('status.state', 'equalto', 'active')
+         | selectattr('createdBy', 'defined')
+         | selectattr('createdBy', 'search', '^gha-os-update')
+         | rejectattr('comment', 'search', 'host=' ~ inventory_hostname ~ ' ')
+         | map(attribute='comment')
+         | list }}
+
+- name: Lost the race — expire our just-created silences before aborting
+  ansible.builtin.uri:
+    url: "{{ os_update_am_url }}/api/v2/silence/{{ item }}"
+    method: DELETE
+    status_code: [200, 404, 500]
+  delegate_to: localhost
+  become: false
+  check_mode: false
+  loop: "{{ os_update_silence_ids }}"
+  failed_when: false
+  when: (os_update_silence_contenders | length) > 0
+
+- name: Guard — this host must be the ONLY holder of an os-update drain window
+  ansible.builtin.assert:
+    that: (os_update_silence_contenders | length) == 0
+    fail_msg: >-
+      Another os-update drain window went up between the guard and our silence:
+      {{ os_update_silence_contenders }}. Our own silences were expired and NOTHING
+      was drained on {{ inventory_hostname }}. Two hosts out of rotation at once is
+      how a redundant pair becomes an outage. STOP.

--- a/ansible/collections/maestra/infra/roles/os_update/tasks/unsilence.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/unsilence.yml
@@ -4,6 +4,39 @@
 # We expire the silences we created; if the runner is killed the endsAt dead-man
 # expires them anyway.
 
+# In undrain-only there are no IDs to loop: os_update_silence_ids is set only by
+# silence.yml, which never runs on that path — the silences we are cleaning up
+# after belong to the DEAD run. Recover them from Alertmanager by the same
+# discriminator guards.yml uses (createdBy gha-os-update + `host=<me> ` with the
+# trailing space), or the stranded silence blocks the next host's one-at-a-time
+# guard until its dead-man endsAt.
+- name: Undrain-only — recover the dead run's silence IDs from Alertmanager
+  when:
+    - os_update_mode == 'undrain-only'
+    - (os_update_silence_ids | default([]) | length) == 0
+  block:
+    - name: Fetch the silences
+      ansible.builtin.uri:
+        url: "{{ os_update_am_url }}/api/v2/silences"
+        return_content: true
+        status_code: 200
+      delegate_to: localhost
+      become: false
+      check_mode: false
+      register: os_update_silences_orphaned
+
+    - name: Adopt the ones this host still owns
+      ansible.builtin.set_fact:
+        os_update_silence_ids: >-
+          {{ os_update_silences_orphaned.json
+             | default([])
+             | selectattr('status.state', 'equalto', 'active')
+             | selectattr('createdBy', 'defined')
+             | selectattr('createdBy', 'search', '^gha-os-update')
+             | selectattr('comment', 'search', 'host=' ~ inventory_hostname ~ ' ')
+             | map(attribute='id')
+             | list }}
+
 - name: Expire the maintenance silences
   ansible.builtin.uri:
     url: "{{ os_update_am_url }}/api/v2/silence/{{ item }}"

--- a/docs/ansible-os-update.md
+++ b/docs/ansible-os-update.md
@@ -21,8 +21,12 @@ CI auth is involved — same as the other public roles already in `requirements.
 collections:
   - name: https://github.com/maestra-io/github-actions.git#/ansible/collections/maestra/infra/
     type: git
-    version: v1.2.0
+    version: main
 ```
+
+`version: main` means the tip of this repo, re-installed by every job: a role change
+merged mid-sweep is picked up by the next host's job, so the hosts of one sweep can run
+different role code.
 
 ## Why GitHub Actions owns the host sequencing
 
@@ -62,7 +66,7 @@ cheerfully unmask the `keepalived`/`haproxy` unit we just masked.
 |---|---|---|---|
 | `vars.yml` | always | set `os_update_peers`, `os_update_farm`, `os_update_pinned_extra`, `os_update_silence_sets` | mutate anything |
 | `preflight.yml` | always, immediately before the drain | assert **every peer** healthy with a live probe (`delegate_to`), and this host safe to reboot | `ignore_errors`, `failed_when: false`, warn-and-continue |
-| `drain.yml` | apply | take the host out of rotation **persistently**, then **prove it from the consumer side** | prove it by "the command succeeded"; `sleep` instead of poll |
+| `drain.yml` | apply | write the drain marker **first** (include the role's `marker.yml` with `os_update_marker_action: write`, before any mutation), then take the host out of rotation **persistently**, then **prove it from the consumer side** | prove it by "the command succeeded"; `sleep` instead of poll |
 | `verify.yml` | apply, after reboot, **before** undrain | prove the host is healthy again, with `until`/`retries` | undrain; touch the peer |
 | `undrain.yml` | **`always`** | put it back, idempotently, safe on a host that was never drained | fail silently |
 | `settle.yml` | apply, after undrain | prove traffic is actually flowing and the pair is redundant again | be a `sleep` |
@@ -113,16 +117,30 @@ purpose — the peer gates there are exactly what fails in the scenario the hatc
 
 ## Running it
 
+Each consumer repo has its own `os-update.yml` shim; targeting is per-repo (the nat-gw
+shim is hard-wired to `_nat_gateway`, haproxy picks the farm via `farm`, vpn picks
+spokes/hubs via `target`):
+
 ```bash
 # read-only, whole farm: pending packages, reboot decision, peer health, /boot headroom
-gh workflow run os-update.yml -f environment=omicron -f role=nat_gateway -f mode=plan
+gh workflow run os-update.yml --repo maestra-io/maestra-nat-gateway \
+  -f environment=omicron -f mode=plan
 
 # one host, for real
-gh workflow run os-update.yml -f environment=omicron -f role=nat_gateway \
-  -f mode=apply -f host_limit=us-omicron-lw-nat-gw-02
+gh workflow run os-update.yml --repo maestra-io/maestra-nat-gateway \
+  -f environment=omicron -f mode=apply -f host_limit=us-omicron-lw-nat-gw-02
 
 # the whole farm, one host at a time, stopping at the first failure
-gh workflow run os-update.yml -f environment=omicron -f role=nat_gateway -f mode=apply
+gh workflow run os-update.yml --repo maestra-io/maestra-nat-gateway \
+  -f environment=omicron -f mode=apply
+
+# haproxy: same shape, plus the farm
+gh workflow run os-update.yml --repo maestra-io/haproxy-maestra \
+  -f environment=omicron -f farm=cdp -f mode=plan
+
+# vpn: same shape, plus spokes|hubs
+gh workflow run os-update.yml --repo maestra-io/vpn-maestra \
+  -f environment=omicron -f target=spokes -f mode=plan
 ```
 
 Idempotency is a derived property, not a state file: a host with an empty upgrade


### PR DESCRIPTION
17 findings from the rolling-os-update deep review (adversarially verified), spanning the reusable workflow, the `maestra.infra.os_update` role and the contract doc. Highlights:

**The escape hatch was bricked three ways** (with maestra-io/maestra-nat-gateway#214 as the consumer-side companion): `mode=undrain-only` was gated behind the plan job, whose preflight fails on a host stranded mid-drain — the hatch never dispatched its apply (GA-01); "Re-run failed jobs" red-looped on a duplicate artifact name (GA-02); and the "drop silences" step was a structural no-op on the undrain-only path, so the dead run's silence suppressed real alerts on the recovered host and blocked the next host's one-at-a-time guard for up to 25 min (ROLE-06/GA-10 — the IDs are now recovered from Alertmanager by the guards.yml discriminator).

**Silences could lie** — timestamps were built from a fact-gathering-frozen epoch with local-TZ strftime and a literal `Z`: on a non-UTC controller the silence was created pending/expired and the host drained+rebooted unsilenced; even on UTC runners the dead-man window silently lost the guards+plan+preflight minutes (ROLE-01, now fresh epoch + `utc=true`). The one-at-a-time interlock had a TOCTOU: guards read silences at play start, ours was POSTed minutes later — two sweeps in one contour (the shims share an Alertmanager; max-parallel:1 only serializes within one workflow) could both drain. Post-POST re-fetch + only-holder assert; the loser expires its own silences and aborts before draining (ROLE-02).

**Gates made honest**: marker-clear and settle individually rescued so unsilence + the final fail always run (ROLE-03); `os_update_needed` computed from pending-minus-pinned so a weekly teleport release no longer drains the whole fleet for a no-op (ROLE-04, same anchored regex as the holds tripwire); unhold failures surface + post-unhold assert (ROLE-05); `order` must list every group host exactly once — omissions were silently dropped from the sweep (GA-06); unknown `mode` fails loudly instead of ending green as a plan (GA-07); soc-rescan also fires after a partial sweep so already-patched hosts don't sit "vulnerable" on the board until the weekly cron (GA-08); a broken dispatch App is reported as broken, not absent (GA-09); `/boot after GC` prints the post-GC number (ROLE-08).

**Doc = contract again**: drain.yml row now requires writing the drain marker first (all three consumers do; a consumer built from the old doc lost resume + the stranded-drain alert); examples are the real shim invocations (`role=` never existed); collection pin documented as `version: main` with the mid-sweep propagation caveat (GA-04/03/05).

Validation: actionlint clean; yaml parse OK on all 7; jq order-validation cases (full/partial/dupe/typo) exercised; jinja2 harness on the real ansible-core 2.20.5 templater — silence timestamps proven correct under TZ=Lisbon/Yerevan/New-York/UTC (|startsAt−now|<1s, window exactly 1500s), pinned-filter fixtures (pinned-only→False, mixed→True, `frrouting-doc` not over-matched), contender/adopt discriminators (`-01` vs `-011` safe); ansible syntax-check green incl. the new block/rescue nesting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)