### PR TITLE
fix(os-update): explicit --ref on the soc vuln-scan dispatch

### DIFF
--- a/.github/workflows/ansible-os-update.yml
+++ b/.github/workflows/ansible-os-update.yml
@@ -438,8 +438,15 @@ jobs:
           fi
 
           echo "Dispatching the SOC vuln-scan (the same weekly workflow) for: ${LIST}"
+          # --ref is EXPLICIT on purpose: without it, gh resolves the default
+          # branch via GraphQL repository.defaultBranchRef, which the App's
+          # actions:write + metadata:read token is NOT allowed to query
+          # ("Resource not accessible by integration") — the dispatch died
+          # there on the first live run after the App secret was fixed
+          # (2026-08-04). The REST dispatch itself needs only actions:write.
           GH_TOKEN="${SOC_TOKEN}" gh workflow run vuln-scan.yaml \
             --repo maestra-io/soc \
+            --ref main \
             -f hosts="${LIST}" \
             -f dry_run=false
 


### PR DESCRIPTION
First live soc-rescan dispatch after the App secret fix died on `unable to determine default branch for maestra-io/soc: GraphQL: Resource not accessible by integration`: without `--ref`, gh resolves the default branch via GraphQL `repository.defaultBranchRef`, which the App token (actions:write + metadata:read) may not query. Explicit `--ref main` skips that lookup; the REST dispatch itself needs only actions:write. Cheaper than widening the App to contents:read.

Consumers pinning the reusable by SHA (vpn-maestra, kubernetes-clusters) need a pin bump to pick this up — follow-up PRs.

Part of issues-maestra#1240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)