### PR TITLE
os-update: size the /boot guard from this host's own kernel, not a constant

### DIFF
--- a/ansible/collections/maestra/infra/roles/os_update/defaults/main.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/defaults/main.yml
@@ -39,7 +39,21 @@ os_update_pinned_extra: []
 # Kernel GC only when /boot is genuinely tight — autoremove --purge has a wider
 # blast radius than "delete old kernels", so we don't run it speculatively.
 os_update_boot_free_gc_threshold_mb: 500
-os_update_boot_free_min_mb: 400
+
+# How much room the /boot guard demands before it will let a host be drained.
+# NOT an absolute MB figure: what the upgrade needs is room to unpack ONE more
+# kernel, and a kernel costs what it costs on THIS host — ~98 MB on the omega
+# kube nodes, more on a host with a fatter initrd. plan.yml measures the largest
+# kernel already in /boot and multiplies by this, so the requirement scales with
+# the machine instead of with a number guessed on a different one.
+#
+# A constant cannot work across the fleet: the kube nodes have a 467 MB /boot,
+# so the old `os_update_boot_free_min_mb: 400` was unsatisfiable there even with
+# a single kernel installed — the guard could never pass, on hosts with 241 MB
+# free and room for two more kernels.
+os_update_boot_free_factor: 2
+# Floor for the pathological case where /boot holds no kernel to measure.
+os_update_boot_free_floor_mb: 150
 
 # Drain marker: survives a runner crash, so a re-run can tell "this host was
 # left drained by a previous run" from "this host is healthy and in rotation".

--- a/ansible/collections/maestra/infra/roles/os_update/tasks/plan.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/plan.yml
@@ -68,11 +68,38 @@
   changed_when: false
   check_mode: false
 
+- name: What one kernel actually costs in /boot on this host
+  # Every file /boot carries per release — vmlinuz + initrd + System.map + config
+  # — summed per release, largest wins. That is the size of the hole the next
+  # kernel has to fit into, measured here rather than assumed, because it varies
+  # by an order of magnitude across the fleet (a stock initrd is ~74 MB; one with
+  # extra firmware or a different compressor is far bigger).
+  # Prints 0 when /boot holds no kernel at all, which the floor then covers.
+  ansible.builtin.shell:
+    executable: /bin/bash
+    cmd: |
+      set -o pipefail
+      shopt -s nullglob
+      max=0
+      for k in /boot/vmlinuz-*; do
+        rel=${k#/boot/vmlinuz-}
+        sz=$(du -cm /boot/*-"$rel" 2>/dev/null | awk '$2 == "total" {print $1}')
+        [ -n "$sz" ] && [ "$sz" -gt "$max" ] && max=$sz
+      done
+      echo "$max"
+  register: os_update_kernel_cost_cmd
+  changed_when: false
+  check_mode: false
+
 - name: Derive the plan
   ansible.builtin.set_fact:
     os_update_holds_before: "{{ os_update_holds_cmd.stdout_lines | default([]) }}"
     os_update_newest_kernel: "{{ os_update_newest_kernel_cmd.stdout | trim }}"
     os_update_boot_free_mb: "{{ os_update_boot_free_cmd.stdout | trim | int }}"
+    # Room for one more kernel, sized off this host's own kernels.
+    os_update_boot_free_needed_mb: >-
+      {{ [((os_update_kernel_cost_cmd.stdout | trim | int) * (os_update_boot_free_factor | int)),
+          (os_update_boot_free_floor_mb | int)] | max }}
     # Pending MINUS pinned: the pinned packages are held before the real upgrade,
     # so a host whose ONLY pending updates are pinned ones (teleport releases
     # near-weekly, and teleport is pinned everywhere) is a guaranteed no-op —
@@ -94,8 +121,13 @@
 
 - name: Guard — /boot must have room to unpack a kernel (a full /boot fails AFTER the drain)
   ansible.builtin.assert:
-    that: (os_update_boot_free_mb | int) >= (os_update_boot_free_min_mb | int)
+    that: (os_update_boot_free_mb | int) >= (os_update_boot_free_needed_mb | int)
     fail_msg: >-
-      /boot has only {{ os_update_boot_free_mb }} MB free (need
-      {{ os_update_boot_free_min_mb }}). Reclaim it first — do not drain a host we
-      then cannot upgrade.
+      /boot has only {{ os_update_boot_free_mb }} MB free; this host's largest
+      kernel occupies {{ os_update_kernel_cost_cmd.stdout | trim }} MB, so the
+      guard wants {{ os_update_boot_free_needed_mb }}
+      (x{{ os_update_boot_free_factor }}, floor {{ os_update_boot_free_floor_mb }}).
+      Reclaim it first — do not drain a host we then cannot upgrade.
+    success_msg: >-
+      /boot free {{ os_update_boot_free_mb }} MB >= {{ os_update_boot_free_needed_mb }}
+      needed (largest kernel here is {{ os_update_kernel_cost_cmd.stdout | trim }} MB).


### PR DESCRIPTION
`os_update_boot_free_min_mb: 400` is **unsatisfiable on the omega kube nodes**. Their `/boot` is a 467 MB partition, so 400 MB free would require it to hold essentially no kernel — the guard could never pass there. It stopped the omega system tier before it touched anything ([run 30945917205](https://github.com/maestra-io/kubernetes-clusters/actions/runs/30945917205)):

```
/boot has only 241 MB free (need 400). Reclaim it first — do not drain a host we then cannot upgrade.
```

Nothing was wrong with the host. 241 MB free, two kernels installed, room for two more.

## One number cannot serve the fleet

What the upgrade needs is room to unpack **one more kernel**, and that costs what it costs on the host in question. Measured across omega just now:

| | kernel in /boot | /boot total | free | old requirement | new requirement |
|---|---|---|---|---|---|
| haproxy / vpn VMs | 53 MB | 881 MB | 597 MB | 400 | **150** (floor) |
| kube nodes | 97 MB | 467 MB | 241 MB | 400 ❌ | **194** ✅ |

Nearly 2× apart on the kernel *and* nearly 2× apart on the partition. `plan.yml` now sums every `/boot` file per kernel release, takes the largest, and demands `os_update_boot_free_factor` (2) × that, with `os_update_boot_free_floor_mb` (150) covering the pathological case where `/boot` holds no kernel to measure.

Net effect: the tier that was blocked on a healthy host proceeds, and every host that already passed still passes — the VMs sat at 597 MB against a 400 MB bar and now sit at 597 against 150.

## Why not just lower the constant

The next fleet with a fatter initrd moves it again — a stock initrd here is 74 MB, one carrying extra firmware or a different compressor is far bigger. The guard should scale with the machine.

The `fail_msg` now prints the measured kernel size beside the requirement, so a genuine "reclaim /boot first" is actionable instead of a bare number, and a `success_msg` records the same in the plan output.

## Verification

The measurement snippet run live on `us-omega-lw-kube-common-system01` — the host that failed:

```
kernel_cost_mb=97
free_mb=241
```

`241 >= max(97*2, 150)` → passes. `yamllint` clean, both files parse.

No consumer overrides `os_update_boot_free_min_mb` (checked `haproxy-maestra`, `vpn-maestra`, `kubernetes-clusters`, `maestra-nat-gateway`), so removing it strands nothing.

Part of [issues-maestra#1240](https://github.com/maestra-io/issues-maestra/issues/1240).

🤖 Generated with [Claude Code](https://claude.com/claude-code)