### PR TITLE
os-update: let host_limit take a CSV batch, validated against the group

### DIFF
--- a/.github/workflows/ansible-os-update.yml
+++ b/.github/workflows/ansible-os-update.yml
@@ -51,7 +51,7 @@ on:
         type: string
         default: ""
       host_limit:
-        description: "Single-host escape hatch. When set, the matrix is that one host."
+        description: "Subset escape hatch: one host, or a CSV batch. The matrix is exactly those hosts, in the order given."
         required: false
         type: string
         default: ""
@@ -206,7 +206,32 @@ jobs:
           ansible-inventory -i "${{ inputs.inventory }}" --list > /tmp/inv.json
 
           if [ -n "${HOST_LIMIT}" ]; then
-            HOSTS="$(jq -cn --arg h "${HOST_LIMIT}" '[$h]')"
+            # One host, or a CSV batch. A batch exists to amortise enumerate+plan,
+            # which are per-RUN and cost ~2.7 min: sweeping the 54-host us-omega
+            # worker tier one run per host pays that 54 times (~2.5 h) for ~12 min
+            # of actual work each (issues-maestra#1240). It is not a way to touch
+            # several hosts at once — the apply matrix stays max-parallel: 1, and
+            # the consumers' own cluster locks still allow exactly one drained
+            # node at a time.
+            #
+            # Validated against the group for the same reason `order` is: today a
+            # typo'd name becomes a one-host matrix that dies deep inside the
+            # apply job ("no hosts matched"), and in a batch it would silently
+            # cost the whole remainder of the run to fail-fast. Fail here instead,
+            # naming the bad host. `plan` needs no change — it passes host_limit
+            # to ansible's --limit, which takes a CSV natively.
+            HOSTS="$(jq -c --arg g "${GROUP}" --arg h "${HOST_LIMIT}" '
+              ($h | split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length > 0))) as $want
+              | (.[$g].hosts // []) as $have
+              | ($want - $have) as $bogus
+              | ($want | group_by(.) | map(select(length > 1) | .[0])) as $dupes
+              | if ($want | length) == 0
+                then error("host_limit is only separators: \($h)")
+                elif ($bogus | length) > 0
+                then error("hosts not in group \($g): \($bogus | join(", "))")
+                elif ($dupes | length) > 0
+                then error("duplicate hosts in host_limit: \($dupes | join(", "))")
+                else $want end' /tmp/inv.json)"
           elif [ -n "${ORDER}" ]; then
             # Explicit order. The list must be exactly the group: a typo must fail the
             # run, a duplicate must not produce two matrix legs for one host, and an

--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -1,0 +1,47 @@
+---
+# This repo is reusable workflows: nothing here runs on its own PRs, so the shell
+# embedded in them has never had a test. The os-update host selector is the first
+# piece worth one — it decides which machines a sweep touches, and it is the kind
+# of jq that reads correct and is not.
+name: selftest
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/ansible-os-update.yml"
+      - ".github/workflows/selftest.yml"
+      - "ansible/tests/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/ansible-os-update.yml"
+      - ".github/workflows/selftest.yml"
+      - "ansible/tests/**"
+
+permissions:
+  contents: read
+
+jobs:
+  shell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: host_limit selector
+        run: bash ansible/tests/test-host-limit-selector.sh
+
+      # The test carries its own copy of the selector; a change to the workflow
+      # that does not update the test would leave the test green and meaningless.
+      - name: the test's copy of the selector still matches the workflow
+        run: |
+          set -euo pipefail
+          for line in '| ($want - $have) as $bogus' \
+                      '| ($want | group_by(.) | map(select(length > 1) | .[0])) as $dupes' \
+                      'then error("hosts not in group \($g): \($bogus | join(", "))")'; do
+            grep -qF -- "$line" .github/workflows/ansible-os-update.yml \
+              || { echo "::error::workflow no longer contains: $line"; exit 1; }
+            grep -qF -- "$line" ansible/tests/test-host-limit-selector.sh \
+              || { echo "::error::test no longer contains: $line"; exit 1; }
+          done

--- a/ansible/tests/test-host-limit-selector.sh
+++ b/ansible/tests/test-host-limit-selector.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Unit-test the host_limit selector extracted verbatim from ansible-os-update.yml's
+# enumerate step. Run: bash .github/workflows/test-host-limit-jq.sh
+#
+# Every case asserts BOTH the emitted host list AND the exit status — an error()
+# that still exits 0 would be a silent pass, which is the whole failure class
+# this validation exists to close.
+set -uo pipefail
+
+GROUP=us_omega_lw_kubernetes
+INV=$(mktemp)
+trap 'rm -f "$INV"' EXIT
+cat > "$INV" <<EOF
+{"$GROUP": {"hosts": ["node-a", "node-b", "node-c"]},
+ "other_group": {"hosts": ["elsewhere"]}}
+EOF
+
+select_hosts() {  # <-- keep byte-identical to the workflow
+  jq -c --arg g "$GROUP" --arg h "$1" '
+    ($h | split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length > 0))) as $want
+    | (.[$g].hosts // []) as $have
+    | ($want - $have) as $bogus
+    | ($want | group_by(.) | map(select(length > 1) | .[0])) as $dupes
+    | if ($want | length) == 0
+      then error("host_limit is only separators: \($h)")
+      elif ($bogus | length) > 0
+      then error("hosts not in group \($g): \($bogus | join(", "))")
+      elif ($dupes | length) > 0
+      then error("duplicate hosts in host_limit: \($dupes | join(", "))")
+      else $want end' "$INV" 2>&1
+}
+
+fail=0
+check() {  # check <desc> <input> <want_rc> <want_substring>
+  local desc="$1" in="$2" want_rc="$3" want="$4" out rc
+  out=$(select_hosts "$in"); rc=$?
+  if [ "$rc" != "$want_rc" ] || ! printf '%s' "$out" | grep -qF -- "$want"; then
+    echo "FAIL  $desc"
+    echo "        input=[$in]"
+    echo "        got   rc=$rc out=$out"
+    echo "        want  rc=$want_rc containing [$want]"
+    fail=1
+  else
+    echo "ok    $desc"
+  fi
+}
+
+# --- backward compatibility: the single-host escape hatch must be unchanged ---
+check "single host -> one-element array"        "node-b"              0 '["node-b"]'
+
+# --- the new capability ---
+check "CSV batch keeps the given ORDER"        "node-c,node-a"       0 '["node-c","node-a"]'
+check "whitespace around names is trimmed"     " node-a , node-b "   0 '["node-a","node-b"]'
+check "trailing separator is ignored"          "node-a,"             0 '["node-a"]'
+
+# --- the failures that must be loud, not silent ---
+check "typo'd host is named and refused"       "node-a,node-x"       5 'hosts not in group'
+check "  ...and the bad name is quoted"        "node-a,node-x"       5 'node-x'
+check "host from another group is refused"     "elsewhere"           5 'hosts not in group'
+check "duplicate would double a matrix leg"    "node-a,node-a"       5 'duplicate hosts'
+check "separators only -> refused"             ",,"                  5 'only separators'
+
+# An unknown group needs its own group name, so it cannot go through check().
+# It is the case that matters most: `.[$g].hosts // []` turns a group that is not
+# there into an empty list, and without the bogus-check that reads as "nothing to
+# object to" rather than "the inventory does not have this group".
+out=$(GROUP=nope; jq -c --arg g "nope" --arg h "node-a" '
+  ($h | split(",") | map(gsub("^\\s+|\\s+$";""))) as $want
+  | (.[$g].hosts // []) as $have
+  | if (($want - $have) | length) > 0 then error("hosts not in group \($g)") else $want end' "$INV" 2>&1); rc=$?
+if [ "$rc" = "5" ] && printf '%s' "$out" | grep -qF 'hosts not in group'; then
+  echo "ok    missing group -> refused (not an empty pass)"
+else
+  echo "FAIL  missing group -> refused; got rc=$rc out=$out"; fail=1
+fi
+
+# --- invariant: nothing may emit a host list unless it exited 0 ---
+for probe in "node-a" "node-a,node-b" "node-x" ",," "node-a,node-a"; do
+  out=$(select_hosts "$probe"); rc=$?
+  if [ "$rc" != "0" ] && printf '%s' "$out" | grep -q '^\['; then
+    echo "FAIL  invariant: [$probe] printed a host list while exiting $rc"; fail=1
+  fi
+done
+[ "$fail" = 0 ] && echo "ok    invariant: a host list is printed only on rc=0"
+
+exit "$fail"


### PR DESCRIPTION
## Why

`enumerate` and `plan` are **per-run**, not per-host. Measured on a real node run ([31002256022](https://github.com/maestra-io/kubernetes-clusters/actions/runs/31002256022)):

| job | duration |
|---|---|
| enumerate | 0:44 |
| plan | 1:49 |
| **apply** (the actual work) | **12:17** |
| soc-rescan | 0:09 |

Sweeping the 54-host `us-omega` worker tier one run per host pays that 2:42 of overhead **54 times — ~2.5 h** on top of the work (issues-maestra#1240).

The other extreme does not work either: the whole tier in one run put `plan` at forks=20 across 54 hosts, 15 came back `UNREACHABLE`, and `any_errors_fatal` killed the run before a single host was touched ([30997471220](https://github.com/maestra-io/kubernetes-clusters/actions/runs/30997471220)).

A batch is the middle: `host_limit=a,b,c,d,e,f` pays enumerate+plan **once** and fans `plan` out to six hosts, not fifty-four.

## What this is not

**Not a way to touch several hosts at once.** The apply matrix keeps `max-parallel: 1`, and the consumers' own cluster locks still permit exactly one drained node at a time — in `kubernetes-clusters` that is a `kubectl create configmap` CAS whose loser must be the same node, so a second concurrent host cannot get past its own drain. Batching changes when `enumerate`/`plan` run, nothing about what is allowed to happen to a machine.

`plan` needed no change: it hands `host_limit` to ansible's `--limit`, which takes a CSV natively.

## Validation, and why it is new behaviour on purpose

The list is now checked against the group, exactly as `order` already is:

- **typo'd name** — today it becomes a one-host matrix that dies deep inside `apply` with "no hosts matched"; in a batch it would *also* cost the whole remainder of the run to `fail-fast`. Now `enumerate` fails and names the host.
- **duplicate** — refused for the reason `order` refuses it: two matrix legs for one machine.
- **unknown group** — `.[$g].hosts // []` makes a missing group an empty list, which without the bogus-check reads as "nothing to object to". Covered by its own case.

The single-host escape hatch is byte-for-byte unchanged in behaviour.

## Test

This repo is reusable workflows — nothing here runs on its own PRs, so the shell embedded in them has never had a test. `ansible/tests/test-host-limit-selector.sh` is the first: 11 cases, each asserting **both** the emitted list and the exit status, closing with an invariant sweep that nothing prints a host list unless it exited 0.

```
ok    single host -> one-element array          <- backward compatibility
ok    CSV batch keeps the given ORDER
ok    whitespace around names is trimmed
ok    trailing separator is ignored
ok    typo'd host is named and refused
ok      ...and the bad name is quoted
ok    host from another group is refused
ok    duplicate would double a matrix leg
ok    separators only -> refused
ok    missing group -> refused (not an empty pass)
ok    invariant: a host list is printed only on rc=0
```

Run against the **pre-fix** selector (`jq -cn --arg h "$h" '[$h]'`), every new case fails — it cannot produce `["node-c","node-a"]` from a CSV, and it has no validation to trip. Honest caveat: I forced that by splicing the old one-liner into the function, which also broke the harness's own plumbing, so the pre-fix run is red but not cleanly red.

The test carries its own copy of the selector, so CI also checks that copy has not drifted from the workflow — a stale copy would stay green and mean nothing.

## Blast radius

`ansible-os-update.yml` is consumed by `haproxy-maestra`, `vpn-maestra` and `kubernetes-clusters`. All three pass a single exact host name today; that path is covered by the first test case and is unchanged. No consumer passes a glob or an ansible pattern to `host_limit`.