### PR TITLE
os-update: contour-scoped one-at-a-time guard — us and eu sweeps are disjoint

### DIFF
--- a/ansible/collections/maestra/infra/roles/os_update/defaults/main.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/defaults/main.yml
@@ -69,3 +69,11 @@ os_update_run_url: manual
 # GH-level fail-fast / approval / artifact trail).
 os_update_allow_multi: false
 os_update_allow_single_node: false
+
+# The contour a drain window belongs to: the region_environment_site triplet
+# of the farm/group name (us_omega_lw_kubernetes -> us_omega_lw). The
+# one-at-a-time guard is scoped to THIS: a us and an eu sweep touch disjoint
+# fleets and must not block each other, while anything sharing the triplet
+# still serializes. Consumers set os_update_farm in their vars.yml before
+# guards run; the default here evaluates lazily.
+os_update_contour: "{{ (os_update_farm.split('_'))[:3] | join('_') }}"

--- a/ansible/collections/maestra/infra/roles/os_update/tasks/guards.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/guards.yml
@@ -27,7 +27,11 @@
   register: os_update_silences
   when: (os_update_am_url | default('')) | length > 0
 
-- name: Which other hosts hold an open os-update drain window
+- name: Which other hosts hold an open os-update drain window (same contour only)
+  # Scoped to os_update_contour (region_environment_site): a us and an eu sweep
+  # touch disjoint fleets and run in parallel by design. A LEGACY silence whose
+  # comment carries no `contour=` token is treated as conflicting (fail safe)
+  # until it expires or its run finishes on new code.
   # The self-exclusion pattern is the PLAIN string `host=<me> ` with a trailing space —
   # not `host=<me>(\s|$)`. This is YAML: inside a folded scalar a backslash is literal,
   # so `(\\s|$)` reached the regex engine as an escaped backslash and never matched.
@@ -47,6 +51,7 @@
          | selectattr('createdBy', 'search', '^gha-os-update')
          | rejectattr('comment', 'search', 'host=' ~ inventory_hostname ~ ' ')
          | map(attribute='comment')
+         | select('search', 'contour=' ~ os_update_contour ~ ' |^(?!.*contour=)')
          | list }}
   when: (os_update_am_url | default('')) | length > 0
 

--- a/ansible/collections/maestra/infra/roles/os_update/tasks/silence.yml
+++ b/ansible/collections/maestra/infra/roles/os_update/tasks/silence.yml
@@ -32,7 +32,7 @@
       startsAt: "{{ '%Y-%m-%dT%H:%M:%S.000Z' | strftime(now().timestamp(), utc=true) }}"
       endsAt: "{{ '%Y-%m-%dT%H:%M:%S.000Z' | strftime(now().timestamp() + (os_update_silence_minutes | int) * 60, utc=true) }}"
       createdBy: "gha-os-update"
-      comment: "OS update issues-maestra#1104 host={{ inventory_hostname }} run={{ os_update_run_url }}"
+      comment: "OS update issues-maestra#1104 contour={{ os_update_contour }} host={{ inventory_hostname }} run={{ os_update_run_url }}"
     status_code: 200
   delegate_to: localhost
   become: false
@@ -72,6 +72,7 @@
          | selectattr('createdBy', 'search', '^gha-os-update')
          | rejectattr('comment', 'search', 'host=' ~ inventory_hostname ~ ' ')
          | map(attribute='comment')
+         | select('search', 'contour=' ~ os_update_contour ~ ' |^(?!.*contour=)')
          | list }}
 
 - name: Lost the race — expire our just-created silences before aborting


### PR DESCRIPTION
The AM-silence one-at-a-time guard treats every `gha-os-update` silence as a conflict, fleet-global. Today the first eu sweep (eu-leaseweb-kube-cdp-common, enabled by kubernetes-clusters#56-59) was refused because a us-omega worker held its drain window (run 31114557423 vs 31113989364) — disjoint clusters, false conflict, and the two sweeps can never run in parallel.

- silence comments now carry `contour=<region>_<environment>_<site>` (`os_update_contour`, derived lazily from `os_update_farm` which every consumer sets before guards run);
- `guards.yml` and the post-silence TOCTOU recheck only count contenders **of the same contour**;
- a legacy silence without the token is treated as conflicting (fail safe) until it expires or its run completes on new code;
- regex verified: same-contour → conflict, other-contour → ignored, legacy → conflict.

In-cluster safety is unchanged — the kube consumer's maintenance-lock ConfigMap still serializes disruptions per cluster, and within a contour the guard behaves exactly as before.

Consumer pin bump (kubernetes-clusters shim) follows after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)