### PR TITLE
ansible-run: optional workload-identity JWT so a play can call AWS as the CI principal

### DIFF
--- a/.github/workflows/ansible-run.yml
+++ b/.github/workflows/ansible-run.yml
@@ -113,6 +113,20 @@ on:
         required: false
         type: string
         default: ""
+      aws_workload_identity:
+        description: >-
+          Mint a Teleport workload-identity JWT ON THE RUNNER and export
+          AWS_WEB_IDENTITY_TOKEN_FILE + AWS_ROLE_ARN into the Execute env, so a play
+          can call AWS as the CI principal instead of every target host needing its
+          own AWS identity. Format: `name=<workload-identity> role_arn=<arn>`.
+          Empty (default) skips the step entirely — inert for every existing caller.
+          Written for os-update's Route53 drain: that flips a haproxy host's weighted
+          record and used to run ON THE HOST with the host's tbot JWT, which only
+          exists where certbot's tbot output does. It does not on the eu-omega CDP
+          farm, so the drain could not run there at all.
+        required: false
+        type: string
+        default: ""
       certificate_ttl:
         description: >-
           Teleport SSH certificate TTL. Must exceed the LONGEST expected play
@@ -406,6 +420,63 @@ jobs:
             echo "TUNNEL_${slug}=http://127.0.0.1:${port}" >> "$GITHUB_ENV"
             echo "tunnel for ${app} is up on 127.0.0.1:${port}"
           done
+
+      # --- Teleport workload identity -> AWS (os-update: the Route53 drain) ---
+      # Same shape as the app-tunnels step above: write a tbot config, join with the
+      # repo's GitHub-OIDC token, run tbot. Here the service is workload-identity-jwt,
+      # which writes a SPIFFE JWT the AWS SDK exchanges for a role via
+      # sts:AssumeRoleWithWebIdentity — the identity lives with the JOB, not with
+      # every host it touches.
+      #
+      # `audiences` is a LIST and the key is plural; the singular `audience` is the
+      # CLI flag, not the config field. Taken from the AWS-OIDC-federation page of
+      # the Teleport docs rather than from memory.
+      - name: Mint a workload-identity JWT for AWS
+        id: aws-wi
+        if: ${{ inputs.aws_workload_identity != '' }}
+        env:
+          AWS_WI: ${{ inputs.aws_workload_identity }}
+        run: |
+          set -euo pipefail
+          name="$(printf '%s' "$AWS_WI" | sed -n 's/.*name=\([^ ]*\).*/\1/p')"
+          role="$(printf '%s' "$AWS_WI" | sed -n 's/.*role_arn=\([^ ]*\).*/\1/p')"
+          if [ -z "$name" ] || [ -z "$role" ]; then
+            echo "::error::malformed aws_workload_identity (want 'name=<wi> role_arn=<arn>'): ${AWS_WI}"
+            exit 1
+          fi
+
+          mkdir -p /tmp/tbot-wi
+          {
+            echo "version: v2"
+            echo "proxy_server: ${{ inputs.teleport_fqdn }}"
+            echo "onboarding:"
+            echo "  join_method: github"
+            echo "  token: ${{ inputs.teleport_join_token }}"
+            echo "storage:"
+            echo "  type: memory"
+            echo "services:"
+            echo "  - type: workload-identity-jwt"
+            echo "    selector:"
+            echo "      name: ${name}"
+            echo "    audiences: ['sts.amazonaws.com']"
+            echo "    destination:"
+            echo "      type: directory"
+            echo "      path: /tmp/tbot-wi"
+          } > /tmp/tbot-wi.yaml
+
+          tbot start -c /tmp/tbot-wi.yaml --oneshot
+
+          # FAIL CLOSED, like the tunnel step: a play that believes it has AWS creds
+          # and does not would drain a host and then fail to withdraw it from DNS.
+          if [ ! -s /tmp/tbot-wi/jwt_svid ]; then
+            echo "::error::tbot produced no JWT SVID at /tmp/tbot-wi/jwt_svid for workload identity '${name}'"
+            ls -la /tmp/tbot-wi || true
+            exit 1
+          fi
+
+          echo "AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/tbot-wi/jwt_svid" >> "$GITHUB_ENV"
+          echo "AWS_ROLE_ARN=${role}" >> "$GITHUB_ENV"
+          echo "workload identity '${name}' minted; AWS role ${role}"
 
       # --- Vault: fetch secrets (public OR tunnel) -----------------------
       - name: Retrieve secrets from Vault

--- a/.github/workflows/ansible-run.yml
+++ b/.github/workflows/ansible-run.yml
@@ -289,8 +289,13 @@ jobs:
 
       - name: Get Teleport version from proxy
         id: tp-version
+        # inputs go through env, never straight into the shell source: GitHub
+        # substitutes ${{ }} BEFORE bash parses, so a quote in a caller-supplied
+        # value would execute in this credentialed job.
+        env:
+          TELEPORT_FQDN: ${{ inputs.teleport_fqdn }}
         run: |
-          VER="$(/usr/bin/curl -sf "https://${{ inputs.teleport_fqdn }}/webapi/find" \
+          VER="$(/usr/bin/curl -sf "https://${TELEPORT_FQDN}/webapi/find" \
             | jq -r '.auto_update.tools_version // .server_version')"
           echo "version=${VER}" >> "$GITHUB_OUTPUT"
 
@@ -340,13 +345,17 @@ jobs:
       - name: Start Vault tunnel via Teleport
         id: vault-tunnel
         if: ${{ inputs.vault_mode == 'tunnel' && inputs.teleport_app != '' }}
+        # See the tp-version step: inputs reach the shell through env only.
+        env:
+          TELEPORT_FQDN: ${{ inputs.teleport_fqdn }}
+          TELEPORT_JOIN_TOKEN: ${{ inputs.teleport_join_token }}
         run: |
           cat > /tmp/tbot-vault-config.yaml <<EOF
           version: v2
           onboarding:
             join_method: github
-            token: ${{ inputs.teleport_join_token }}
-          proxy_server: ${{ inputs.teleport_fqdn }}
+            token: ${TELEPORT_JOIN_TOKEN}
+          proxy_server: ${TELEPORT_FQDN}
           # memory storage: default /var/lib/teleport is not writable on hosted
           # runners (mkdir: permission denied -> tunnel never opens).
           storage:
@@ -369,14 +378,16 @@ jobs:
         if: ${{ inputs.tbot_tunnels != '' }}
         env:
           TBOT_TUNNELS: ${{ inputs.tbot_tunnels }}
+          TELEPORT_FQDN: ${{ inputs.teleport_fqdn }}
+          TELEPORT_JOIN_TOKEN: ${{ inputs.teleport_join_token }}
         run: |
           set -euo pipefail
           {
             echo "version: v2"
-            echo "proxy_server: ${{ inputs.teleport_fqdn }}"
+            echo "proxy_server: ${TELEPORT_FQDN}"
             echo "onboarding:"
             echo "  join_method: github"
-            echo "  token: ${{ inputs.teleport_join_token }}"
+            echo "  token: ${TELEPORT_JOIN_TOKEN}"
             # memory storage: /var/lib/teleport is not writable on hosted runners.
             echo "storage:"
             echo "  type: memory"
@@ -436,6 +447,8 @@ jobs:
         if: ${{ inputs.aws_workload_identity != '' }}
         env:
           AWS_WI: ${{ inputs.aws_workload_identity }}
+          TELEPORT_FQDN: ${{ inputs.teleport_fqdn }}
+          TELEPORT_JOIN_TOKEN: ${{ inputs.teleport_join_token }}
         run: |
           set -euo pipefail
           name="$(printf '%s' "$AWS_WI" | sed -n 's/.*name=\([^ ]*\).*/\1/p')"
@@ -448,10 +461,10 @@ jobs:
           mkdir -p /tmp/tbot-wi
           {
             echo "version: v2"
-            echo "proxy_server: ${{ inputs.teleport_fqdn }}"
+            echo "proxy_server: ${TELEPORT_FQDN}"
             echo "onboarding:"
             echo "  join_method: github"
-            echo "  token: ${{ inputs.teleport_join_token }}"
+            echo "  token: ${TELEPORT_JOIN_TOKEN}"
             echo "storage:"
             echo "  type: memory"
             echo "services:"

--- a/docs/ansible-reusable-workflows.md
+++ b/docs/ansible-reusable-workflows.md
@@ -48,6 +48,7 @@ Never prefix them with `ansible/`. Only `requirements_pip` / `requirements_galax
 | `vault_secrets` | string (multiline) | no | `""` | passed **verbatim** to `hashicorp/vault-action` `secrets:` — the whole per-repo secret map |
 | `mint_proxmox_token` | boolean | no | `false` | proxmox-only pveum token mint + cleanup (input-gated) |
 | `extra_env` | string (multiline) | no | `""` | extra `KEY=VALUE` lines injected into the Execute env |
+| `aws_workload_identity` | string | no | `""` | `name=<workload-identity> role_arn=<arn>` — mints a Teleport workload-identity JWT **on the runner** and exports `AWS_WEB_IDENTITY_TOKEN_FILE` / `AWS_ROLE_ARN` into the Execute env, so a play calls AWS as the CI principal instead of every target host needing its own AWS identity. Empty skips the step. Fails the job if no JWT is produced. |
 | `extra_run_args` | string | no | `""` | extra `ansible-playbook` args (e.g. `-e vault_consul_template_token=…`) |
 | `gh_environment` | string | no | `""` | GitHub Environment approval gate; empty → ungated |
 | `artifact_name` | string | no | derived | plan/apply log artifact name (`ansible-check-<r>-<e>-<s><suffix>`) |


### PR DESCRIPTION
Third of the chain that moves the os-update Route53 drain off the host. The IAM role ([aws-infra#33](https://github.com/maestra-io/aws-infra/pull/33)) and the Teleport bot/identity ([fluxcd#8179](https://github.com/maestra-io/fluxcd/pull/8179)) are already **live**, so this is usable immediately.

## Inert by default

New input `aws_workload_identity`, default empty → the step is skipped and every existing caller is byte-identical.

## Why

os-update drains a haproxy host by flipping its weighted Route53 record, and that script runs **on the host**, authenticating with the host's own tbot JWT. That only works where certbot's tbot output exists. The eu-omega CDP farm has no certbot at all:

```
FileNotFoundError: [Errno 2] No such file or directory: '/run/tbot/jwt_svid'
```

so that pair cannot be drained, and therefore cannot be patched. Giving every farm an AWS identity purely to be drainable is the wrong direction — flipping a DNS weight is a control-plane action and the job is already an authenticated principal, so the identity belongs with the **job**.

## Shape

Same as the existing app-tunnels step: write a tbot config, join with the repo's GitHub-OIDC token, run tbot. Here the service is `workload-identity-jwt`, whose SPIFFE JWT the AWS SDK exchanges via `sts:AssumeRoleWithWebIdentity`. `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_ARN` go out through `$GITHUB_ENV`, so `Execute Ansible` picks them up with no further wiring.

**Fails closed**, like the tunnel step: an empty or missing JWT is an error. A play that believes it has AWS credentials and does not would drain a host and then fail to withdraw it from DNS — worse than not starting.

## Two details taken from the docs, not from memory

`audiences` is a **list** and the key is **plural** — the singular `audience` is the CLI flag, not the config field. And the echo uses single quotes inside, so there is no shell escaping to reason about; a first draft used `\"` and my local render of the generated config is what caught it.

## Verified locally

- the workflow parses;
- the generated tbot config was rendered **the way the shell emits it**, parsed as YAML, and asserted field-by-field against the documented `workload-identity-jwt` schema:

```yaml
services:
  - type: workload-identity-jwt
    selector:
      name: os-update
    audiences: ['sts.amazonaws.com']
    destination:
      type: directory
      path: /tmp/tbot-wi
```

Next: haproxy-maestra's `drain.yml`/`undrain.yml` move to `delegate_to: localhost`, and the host-side `boto3`/tbot requirements go away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds optional AWS workload identity support to the `ansible-run` workflow.

When `aws_workload_identity` is set, the workflow:

- Validates the workload identity name and AWS role ARN.
- Uses the repository GitHub OIDC token to join Teleport.
- Generates a `workload-identity-jwt` configuration with the `os-update` selector and `sts.amazonaws.com` audience.
- Verifies that Teleport creates a JWT SVID.
- Exports `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_ARN` through `$GITHUB_ENV`.

The input defaults to empty, so existing callers keep the current behavior. Empty or missing JWT output fails the workflow. No breaking changes are introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->