### PR TITLE
ansible-os-update: forward aws_workload_identity to the apply job

### DIFF
--- a/.github/workflows/ansible-os-update.yml
+++ b/.github/workflows/ansible-os-update.yml
@@ -92,6 +92,17 @@ on:
         required: false
         type: string
         default: "1h"
+      aws_workload_identity:
+        description: >-
+          Forwarded to ansible-run on the APPLY job: `name=<workload-identity>
+          role_arn=<arn>` mints a Teleport workload-identity JWT on the RUNNER so the
+          play can call AWS as the CI principal. Empty (default) changes nothing.
+          haproxy's drain flips a weighted Route53 record and used to do that ON THE
+          HOST with the host's own tbot JWT — which exists only where certbot's does,
+          so a farm without certbot could not be drained at all.
+        required: false
+        type: string
+        default: ""
       max_hosts:
         description: "Refuse to run if the group is bigger than this (typo/label-drift guard)."
         required: false
@@ -355,6 +366,9 @@ jobs:
       use_mitogen: false
       no_hosts_fail_on_apply: true
       certificate_ttl: ${{ inputs.certificate_ttl }}
+      # apply only — the plan job runs preflight and never touches Route53.
+      # undrain-only routes through THIS job too, so the restore is covered.
+      aws_workload_identity: ${{ inputs.aws_workload_identity }}
       tbot_tunnels: |
         app=${{ inputs.alertmanager_app }} listen=9093
       extra_run_args: >-


### PR DESCRIPTION
#42 added `aws_workload_identity` to `ansible-run`, but `workflow_call` has **no passthrough** — an input a caller cannot set is an input that does nothing.

The os-update chain is `shim → ansible-os-update → ansible-run`, so without this the JWT step could never fire for the very workflow it was written for.

Forwarded from the **apply** job only:
- the **plan** job runs preflight and never touches Route53;
- **undrain-only** routes through the apply job as well, so both the drain and the restore are covered.

Caught by walking the caller chain rather than assuming the input was reachable — the same *"find its other homes"* check that cost three repeats in haproxy-maestra this week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds the optional `aws_workload_identity` input to `ansible-os-update.yml`. The `apply` job forwards this input to `ansible-run.yml` for Route53 operations, including `undrain-only` workflows. The `plan` job remains unchanged because it does not access Route53.

No breaking changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->