### PR TITLE
ansible-run: optional break-glass SecretID minter token (issue 939 Phase 3.6)

### DIFF
--- a/.github/workflows/ansible-run.yml
+++ b/.github/workflows/ansible-run.yml
@@ -152,6 +152,22 @@ on:
         required: false
         type: string
         default: ""
+      breakglass_minter_role:
+        description: >-
+          Vault jwt-github role used ONLY to mint response-wrapped AppRole
+          SecretIDs for break-glass console enrolment (issues-maestra#939), e.g.
+          `breakglass-secretid-minter-proxmox`. Sets BREAKGLASS_MINT_TOKEN in the
+          Execute env; empty (default) skips the step entirely, so every existing
+          caller is unaffected.
+          This is a SEPARATE identity from vault_role on purpose. Its policy can
+          create wrapped SecretIDs and nothing else — no read capability exists
+          anywhere in that plane, so neither this token nor the host token it
+          leads to can retrieve any host's console credential. Keep it that way:
+          granting the ordinary <repo>-github-ci role this power, or adding a
+          read path, is what the design exists to prevent.
+        required: false
+        type: string
+        default: ""
       # --- proxmox-only optional pre-step (divergence class 1) -----------
       mint_proxmox_token:
         description: "Mint a per-run Proxmox pveum API token via tsh ssh (proxmox repo only)."
@@ -511,6 +527,34 @@ jobs:
           jwtGithubAudience: https://github.com/maestra-io
           exportEnv: true
           secrets: ${{ inputs.vault_secrets }}
+
+      # --- Vault: break-glass SecretID minter token (input-gated) --------
+      # Logs in as a dedicated jwt-github role and exports BREAKGLASS_MINT_TOKEN.
+      # Done by hand rather than through hashicorp/vault-action because that
+      # action's exportToken writes the credential to the well-known VAULT_TOKEN
+      # name for every later step; this token belongs to one narrow purpose and
+      # gets its own name. No jq: the ARC runner image is minimal, python3 is
+      # already set up above.
+      - name: Mint the break-glass minter token
+        if: ${{ inputs.breakglass_minter_role != '' }}
+        env:
+          BG_VAULT_ADDR: ${{ inputs.vault_addr }}
+          BG_ROLE: ${{ inputs.breakglass_minter_role }}
+        run: |
+          set -euo pipefail
+          BG_JWT=$(curl -sSf -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+                     "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://github.com/maestra-io" \
+                   | python3 -c 'import json,sys; print(json.load(sys.stdin)["value"])')
+          export BG_JWT
+          # The JWT and the role go to python through the ENVIRONMENT, never
+          # interpolated into a command line, so neither lands in a rendered
+          # argv or in the log.
+          token=$(python3 -c 'import json,os; print(json.dumps({"role": os.environ["BG_ROLE"], "jwt": os.environ["BG_JWT"]}))' \
+                  | curl -sSf -X POST --data @- "${BG_VAULT_ADDR}/v1/auth/jwt-github/login" \
+                  | python3 -c 'import json,sys; print(json.load(sys.stdin)["auth"]["client_token"])')
+          echo "::add-mask::${token}"
+          echo "BREAKGLASS_MINT_TOKEN=${token}" >> "$GITHUB_ENV"
+          echo "break-glass minter token acquired as role ${BG_ROLE}"
 
       # --- Proxmox pveum token (divergence class 1, input-gated) ---------
       - name: Mint Proxmox API token


### PR DESCRIPTION
Adds one optional input, `breakglass_minter_role`, to the central `ansible-run.yml`. Empty by default, so **every existing caller is unaffected** — the step does not run at all.

## Why

Phase 3.6 of [issues-maestra#939](https://github.com/maestra-io/issues-maestra/issues/939) provisions per-host break-glass **console** credentials from CI, so a newly built host converges with no human step. The design keeps CI unable to read any credential: the host generates its own seed locally and pushes it to a Vault KV plane that is **write-only for machines**. The controller's only job is to hand the host a single-use, response-wrapped AppRole SecretID — and minting those is the one capability this workflow was missing.

The Vault side (dedicated mount, write-only host policy, mandatory response wrapping via `min_wrapping_ttl`, and the per-repo `breakglass-secretid-minter-*` roles) is [development/vault!2862](https://mindbox.gitlab.yandexcloud.net/development/vault/-/merge_requests/2862).

## What it does

Logs in to `jwt-github` as the named role and exports `BREAKGLASS_MINT_TOKEN` for the Execute step. That role is deliberately **separate** from `vault_role`: its policy can create wrapped SecretIDs and read the role-id, nothing else. There is no read path anywhere in that plane, so neither this token nor the host token it leads to can retrieve a console credential for any host.

Two implementation choices, both deliberate:

- not `hashicorp/vault-action` with `exportToken`, because that publishes the credential under the well-known `VAULT_TOKEN` name to every later step; this token has one narrow purpose and gets its own name;
- `python3` (already set up by the workflow) parses the JSON rather than `jq`, which the minimal ARC runner image does not have. The JWT and the role reach python through the environment, never interpolated into a command line, so neither appears in a rendered argv; the resulting token is `::add-mask::`ed before it touches `GITHUB_ENV`.

## Checked locally

`actionlint` output is unchanged by this diff — 5 pre-existing findings before and after, differing only in line numbers. The JSON build and the login-response parse were exercised directly, including a JWT containing a quote and a `$` to prove the environment-passing holds. The OIDC request itself can only be exercised in a real job; the first consumer is `proxmox`, canaried on a single omicron host.
