### PR TITLE
ansible-run: give each run its own Proxmox API token

### DIFF
--- a/.github/workflows/ansible-run.yml
+++ b/.github/workflows/ansible-run.yml
@@ -565,18 +565,27 @@ jobs:
           TELEPORT_PROXY: ${{ inputs.teleport_fqdn }}
         run: |
           set -euo pipefail
-          # Pick a candidate proxmox node in this region/env/site and mint a github-ci token.
+          # The token name is per-RUN. It used to be the fixed `github-ci`, which
+          # every job in the repo minted with `token remove` + `token add` and
+          # deleted again on the way out — so any two overlapping runs shared one
+          # credential and the second one silently invalidated the first. Seen on
+          # maestra-io/proxmox run 31637270407: a deploy on `serial: 1` was on its
+          # third hypervisor when a PR-check run tore the token down, and that
+          # host alone failed with `no such token 'github-ci' for user
+          # 'ansible-ci@pve'`. A unique name per run removes the collision
+          # entirely; the id is exported so the play can address it.
+          TOKEN_NAME="github-ci-${{ github.run_id }}"
           NODES="$(tsh ls --format=names \
             "role=proxmox,region=${{ inputs.region }},environment=${{ inputs.environment }},site=${{ inputs.site }}" || true)"
           TOKEN_VALUE=""
           TOKEN_NODE=""
           for NODE in $(echo "$NODES" | shuf); do
-            OUT="$(timeout 30 tsh ssh --login=teleport-production "$NODE" '
+            OUT="$(timeout 30 tsh ssh --login=teleport-production "$NODE" "
               sudo pveum user add ansible-ci@pve 2>/dev/null || true
               sudo pveum acl modify / -user ansible-ci@pve -role Administrator
-              sudo pveum user token remove ansible-ci@pve github-ci 2>/dev/null || true
-              sudo pveum user token add ansible-ci@pve github-ci --privsep=0 --output-format=json
-            ' 2>/dev/null || true)"
+              sudo pveum user token remove ansible-ci@pve ${TOKEN_NAME} 2>/dev/null || true
+              sudo pveum user token add ansible-ci@pve ${TOKEN_NAME} --privsep=0 --output-format=json
+            " 2>/dev/null || true)"
             TOKEN="$(echo "$OUT" | jq -r '.value // empty' 2>/dev/null || true)"
             if [ -n "$TOKEN" ]; then
               TOKEN_VALUE="$TOKEN"
@@ -590,7 +599,9 @@ jobs:
           fi
           echo "::add-mask::$TOKEN_VALUE"
           echo "PROXMOX_API_TOKEN_SECRET=$TOKEN_VALUE" >> "$GITHUB_ENV"
+          echo "PROXMOX_API_TOKEN_NAME=$TOKEN_NAME" >> "$GITHUB_ENV"
           echo "node=$TOKEN_NODE" >> "$GITHUB_OUTPUT"
+          echo "token_name=$TOKEN_NAME" >> "$GITHUB_OUTPUT"
 
       # --- Execute -------------------------------------------------------
       - name: Execute Ansible
@@ -702,8 +713,9 @@ jobs:
       - name: Cleanup Proxmox API token
         if: ${{ always() && inputs.mint_proxmox_token && steps.mint-proxmox.outputs.node != '' }}
         run: |
+          # Removes only THIS run's token, so a concurrent job keeps its own.
           timeout 30 tsh ssh --login=teleport-production "${{ steps.mint-proxmox.outputs.node }}" \
-            'sudo pveum user token remove ansible-ci@pve github-ci' || true
+            "sudo pveum user token remove ansible-ci@pve ${{ steps.mint-proxmox.outputs.token_name }}" || true
 
       - name: Generate summary
         if: ${{ always() }}

--- a/.github/workflows/ansible-run.yml
+++ b/.github/workflows/ansible-run.yml
@@ -563,6 +563,14 @@ jobs:
         env:
           TELEPORT_IDENTITY_FILE: ${{ steps.teleport-auth.outputs.identity-file || steps.teleport-auth-retry.outputs.identity-file }}
           TELEPORT_PROXY: ${{ inputs.teleport_fqdn }}
+          # Through the environment, not interpolated into the script: an
+          # interpolated value is pasted in before bash parses the line, so a
+          # quote in it would be code rather than data. Same reasoning the
+          # Execute step already documents for its free-text dispatch inputs.
+          TF_REGION: ${{ inputs.region }}
+          TF_ENVIRONMENT: ${{ inputs.environment }}
+          TF_SITE: ${{ inputs.site }}
+          GH_RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
           # The token name is per-RUN. It used to be the fixed `github-ci`, which
@@ -574,9 +582,14 @@ jobs:
           # host alone failed with `no such token 'github-ci' for user
           # 'ansible-ci@pve'`. A unique name per run removes the collision
           # entirely; the id is exported so the play can address it.
-          TOKEN_NAME="github-ci-${{ github.run_id }}"
+          TOKEN_NAME="github-ci-${GH_RUN_ID}"
+          # Server-side expiry, so a cleanup that never runs — cancelled job,
+          # runner death — cannot leave an Administrator token alive forever.
+          # Two hours covers any run this workflow performs; the cleanup step
+          # still removes it immediately on the normal path.
+          TOKEN_EXPIRE="$(( $(date +%s) + 7200 ))"
           NODES="$(tsh ls --format=names \
-            "role=proxmox,region=${{ inputs.region }},environment=${{ inputs.environment }},site=${{ inputs.site }}" || true)"
+            "role=proxmox,region=${TF_REGION},environment=${TF_ENVIRONMENT},site=${TF_SITE}" || true)"
           TOKEN_VALUE=""
           TOKEN_NODE=""
           for NODE in $(echo "$NODES" | shuf); do
@@ -584,7 +597,7 @@ jobs:
               sudo pveum user add ansible-ci@pve 2>/dev/null || true
               sudo pveum acl modify / -user ansible-ci@pve -role Administrator
               sudo pveum user token remove ansible-ci@pve ${TOKEN_NAME} 2>/dev/null || true
-              sudo pveum user token add ansible-ci@pve ${TOKEN_NAME} --privsep=0 --output-format=json
+              sudo pveum user token add ansible-ci@pve ${TOKEN_NAME} --privsep=0 --expire ${TOKEN_EXPIRE} --output-format=json
             " 2>/dev/null || true)"
             TOKEN="$(echo "$OUT" | jq -r '.value // empty' 2>/dev/null || true)"
             if [ -n "$TOKEN" ]; then
@@ -712,10 +725,15 @@ jobs:
       # --- Proxmox token cleanup -----------------------------------------
       - name: Cleanup Proxmox API token
         if: ${{ always() && inputs.mint_proxmox_token && steps.mint-proxmox.outputs.node != '' }}
+        env:
+          PVE_NODE: ${{ steps.mint-proxmox.outputs.node }}
+          PVE_TOKEN_NAME: ${{ steps.mint-proxmox.outputs.token_name }}
         run: |
           # Removes only THIS run's token, so a concurrent job keeps its own.
-          timeout 30 tsh ssh --login=teleport-production "${{ steps.mint-proxmox.outputs.node }}" \
-            "sudo pveum user token remove ansible-ci@pve ${{ steps.mint-proxmox.outputs.token_name }}" || true
+          # Both values arrive through the environment rather than being pasted
+          # into the script text (see the mint step).
+          timeout 30 tsh ssh --login=teleport-production "$PVE_NODE" \
+            "sudo pveum user token remove ansible-ci@pve $PVE_TOKEN_NAME" || true
 
       - name: Generate summary
         if: ${{ always() }}


### PR DESCRIPTION
Two overlapping runs currently share one Proxmox credential.

The mint step uses a fixed token name, `github-ci`, creating it with `token remove` + `token add` and deleting it again in cleanup. So a second run's mint invalidates the first run's secret, and whichever job finishes first deletes the token out from under the other.

**Observed today**, [maestra-io/proxmox run 31637270407](https://github.com/maestra-io/proxmox/actions/runs/31637270407): a deploy walking hypervisors with `serial: 1` had just succeeded on hosts 01 and 02 when a PR-check run started at 20:23 and tore the token down; host 03 then failed at 20:27 with

```
pveproxy[60354]: authentication failure: no such token 'github-ci' for user 'ansible-ci@pve'
```

The cluster was quorate, both API daemons healthy, and that same host had deployed cleanly three hours earlier — it is purely the shared name.

## Fix

Name the token `github-ci-<run_id>`, export `PROXMOX_API_TOKEN_NAME` alongside the secret, and have cleanup remove only this run's token. Callers that do not read the new variable are unaffected — they keep their own default name — and the change is inert for anything that does not set `mint_proxmox_token`.

The consuming side lands in `maestra-io/proxmox` together with a pin bump.

## Checked locally

`actionlint` output is unchanged by the diff (5 pre-existing findings before and after). The remote command was rendered and inspected to confirm the token name interpolates on the runner rather than in the remote shell:

```
sudo pveum user token remove ansible-ci@pve github-ci-31637270407
sudo pveum user token add ansible-ci@pve github-ci-31637270407 --privsep=0 --output-format=json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates the `ansible-run` workflow to create a unique Proxmox API token for each GitHub Actions run. The workflow uses `github-ci-<run_id>`, exports `PROXMOX_API_TOKEN_NAME`, and removes only the token created by that run.

This prevents overlapping runs from invalidating or deleting each other’s credentials. Existing callers remain unchanged when `PROXMOX_API_TOKEN_NAME` is not used. The change applies only when `mint_proxmox_token` is configured.

No breaking changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->